### PR TITLE
Fix plural resource mapping bug for time restrictions

### DIFF
--- a/provider/cmd/pulumi-resource-opsgenie/schema.json
+++ b/provider/cmd/pulumi-resource-opsgenie/schema.json
@@ -167,10 +167,22 @@
         },
         "opsgenie:index/AlertPolicyTimeRestriction:AlertPolicyTimeRestriction": {
             "properties": {
-                "restrictions": {
+                "restriction": {
                     "type": "array",
                     "items": {
                         "$ref": "#/types/opsgenie:index/AlertPolicyTimeRestrictionRestriction:AlertPolicyTimeRestrictionRestriction"
+                    },
+                    "description": "A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "restrictionList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/opsgenie:index/AlertPolicyTimeRestrictionRestrictionList:AlertPolicyTimeRestrictionRestrictionList"
                     },
                     "description": "List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.\n",
                     "language": {
@@ -195,6 +207,53 @@
             ]
         },
         "opsgenie:index/AlertPolicyTimeRestrictionRestriction:AlertPolicyTimeRestrictionRestriction": {
+            "properties": {
+                "endHour": {
+                    "type": "integer",
+                    "description": "Ending hour of restriction.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "endMin": {
+                    "type": "integer",
+                    "description": "Ending minute of restriction on defined `end_hour`\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startHour": {
+                    "type": "integer",
+                    "description": "Starting hour of restriction.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startMin": {
+                    "type": "integer",
+                    "description": "Staring minute of restriction on defined `start_hour`\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "endHour",
+                "endMin",
+                "startHour",
+                "startMin"
+            ]
+        },
+        "opsgenie:index/AlertPolicyTimeRestrictionRestrictionList:AlertPolicyTimeRestrictionRestrictionList": {
             "properties": {
                 "endDay": {
                     "type": "string",
@@ -1832,10 +1891,10 @@
                         }
                     }
                 },
-                "restrictions": {
+                "restrictionList": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/types/opsgenie:index/NotificationPolicyTimeRestrictionRestriction:NotificationPolicyTimeRestrictionRestriction"
+                        "$ref": "#/types/opsgenie:index/NotificationPolicyTimeRestrictionRestrictionList:NotificationPolicyTimeRestrictionRestrictionList"
                     },
                     "description": "List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.\n",
                     "language": {
@@ -1860,6 +1919,53 @@
             ]
         },
         "opsgenie:index/NotificationPolicyTimeRestrictionRestriction:NotificationPolicyTimeRestrictionRestriction": {
+            "properties": {
+                "endHour": {
+                    "type": "integer",
+                    "description": "Ending hour of restriction.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "endMin": {
+                    "type": "integer",
+                    "description": "Ending minute of restriction on defined `end_hour`\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startHour": {
+                    "type": "integer",
+                    "description": "Starting hour of restriction.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startMin": {
+                    "type": "integer",
+                    "description": "Staring minute of restriction on defined `start_hour`\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "endHour",
+                "endMin",
+                "startHour",
+                "startMin"
+            ]
+        },
+        "opsgenie:index/NotificationPolicyTimeRestrictionRestrictionList:NotificationPolicyTimeRestrictionRestrictionList": {
             "properties": {
                 "endDay": {
                     "type": "string",
@@ -2264,10 +2370,10 @@
                         }
                     }
                 },
-                "restrictions": {
+                "restrictionList": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/types/opsgenie:index/ScheduleRotationTimeRestrictionRestriction:ScheduleRotationTimeRestrictionRestriction"
+                        "$ref": "#/types/opsgenie:index/ScheduleRotationTimeRestrictionRestrictionList:ScheduleRotationTimeRestrictionRestrictionList"
                     },
                     "description": "It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.\n",
                     "language": {
@@ -2292,6 +2398,53 @@
             ]
         },
         "opsgenie:index/ScheduleRotationTimeRestrictionRestriction:ScheduleRotationTimeRestrictionRestriction": {
+            "properties": {
+                "endHour": {
+                    "type": "integer",
+                    "description": "Value of the hour that frame will end.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "endMin": {
+                    "type": "integer",
+                    "description": "Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startHour": {
+                    "type": "integer",
+                    "description": "Value of the hour that frame will start.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startMin": {
+                    "type": "integer",
+                    "description": "Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.\n",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "endHour",
+                "endMin",
+                "startHour",
+                "startMin"
+            ]
+        },
+        "opsgenie:index/ScheduleRotationTimeRestrictionRestrictionList:ScheduleRotationTimeRestrictionRestrictionList": {
             "properties": {
                 "endDay": {
                     "type": "string",
@@ -2733,10 +2886,10 @@
                         }
                     }
                 },
-                "restrictions": {
+                "restrictionList": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/types/opsgenie:index/TeamRoutingRuleTimeRestrictionRestriction:TeamRoutingRuleTimeRestrictionRestriction"
+                        "$ref": "#/types/opsgenie:index/TeamRoutingRuleTimeRestrictionRestrictionList:TeamRoutingRuleTimeRestrictionRestrictionList"
                     },
                     "language": {
                         "python": {
@@ -2759,6 +2912,49 @@
             ]
         },
         "opsgenie:index/TeamRoutingRuleTimeRestrictionRestriction:TeamRoutingRuleTimeRestrictionRestriction": {
+            "properties": {
+                "endHour": {
+                    "type": "integer",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "endMin": {
+                    "type": "integer",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startHour": {
+                    "type": "integer",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                },
+                "startMin": {
+                    "type": "integer",
+                    "language": {
+                        "python": {
+                            "mapCase": false
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "endHour",
+                "endMin",
+                "startHour",
+                "startMin"
+            ]
+        },
+        "opsgenie:index/TeamRoutingRuleTimeRestrictionRestrictionList:TeamRoutingRuleTimeRestrictionRestrictionList": {
             "properties": {
                 "endDay": {
                     "type": "string",
@@ -3031,7 +3227,7 @@
     },
     "resources": {
         "opsgenie:index/alertPolicy:AlertPolicy": {
-            "description": "Manages a Alert Policy within Opsgenie.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as opsgenie from \"@pulumi/opsgenie\";\n\nconst testTeam = new opsgenie.Team(\"testTeam\", {description: \"This team deals with all the things\"});\nconst testAlertPolicy = new opsgenie.AlertPolicy(\"testAlertPolicy\", {\n    teamId: testTeam.id,\n    policyDescription: \"This is sample policy\",\n    message: \"{{message}}\",\n    filters: [{}],\n    timeRestrictions: [{\n        type: \"weekday-and-time-of-day\",\n        restrictions: [\n            {\n                endDay: \"monday\",\n                endHour: 7,\n                endMin: 0,\n                startDay: \"sunday\",\n                startHour: 21,\n                startMin: 0,\n            },\n            {\n                endDay: \"tuesday\",\n                endHour: 7,\n                endMin: 0,\n                startDay: \"monday\",\n                startHour: 22,\n                startMin: 0,\n            },\n        ],\n    }],\n});\n```\n```python\nimport pulumi\nimport pulumi_opsgenie as opsgenie\n\ntest_team = opsgenie.Team(\"testTeam\", description=\"This team deals with all the things\")\ntest_alert_policy = opsgenie.AlertPolicy(\"testAlertPolicy\",\n    team_id=test_team.id,\n    policy_description=\"This is sample policy\",\n    message=\"{{message}}\",\n    filters=[opsgenie.AlertPolicyFilterArgs()],\n    time_restrictions=[opsgenie.AlertPolicyTimeRestrictionArgs(\n        type=\"weekday-and-time-of-day\",\n        restrictions=[\n            opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(\n                end_day=\"monday\",\n                end_hour=7,\n                end_min=0,\n                start_day=\"sunday\",\n                start_hour=21,\n                start_min=0,\n            ),\n            opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(\n                end_day=\"tuesday\",\n                end_hour=7,\n                end_min=0,\n                start_day=\"monday\",\n                start_hour=22,\n                start_min=0,\n            ),\n        ],\n    )])\n```\n```csharp\nusing Pulumi;\nusing Opsgenie = Pulumi.Opsgenie;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var testTeam = new Opsgenie.Team(\"testTeam\", new Opsgenie.TeamArgs\n        {\n            Description = \"This team deals with all the things\",\n        });\n        var testAlertPolicy = new Opsgenie.AlertPolicy(\"testAlertPolicy\", new Opsgenie.AlertPolicyArgs\n        {\n            TeamId = testTeam.Id,\n            PolicyDescription = \"This is sample policy\",\n            Message = \"{{message}}\",\n            Filters = \n            {\n                ,\n            },\n            TimeRestrictions = \n            {\n                new Opsgenie.Inputs.AlertPolicyTimeRestrictionArgs\n                {\n                    Type = \"weekday-and-time-of-day\",\n                    Restrictions = \n                    {\n                        new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionArgs\n                        {\n                            EndDay = \"monday\",\n                            EndHour = 7,\n                            EndMin = 0,\n                            StartDay = \"sunday\",\n                            StartHour = 21,\n                            StartMin = 0,\n                        },\n                        new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionArgs\n                        {\n                            EndDay = \"tuesday\",\n                            EndHour = 7,\n                            EndMin = 0,\n                            StartDay = \"monday\",\n                            StartHour = 22,\n                            StartMin = 0,\n                        },\n                    },\n                },\n            },\n        });\n    }\n\n}\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-opsgenie/sdk/go/opsgenie\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestTeam, err := opsgenie.NewTeam(ctx, \"testTeam\", \u0026opsgenie.TeamArgs{\n\t\t\tDescription: pulumi.String(\"This team deals with all the things\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = opsgenie.NewAlertPolicy(ctx, \"testAlertPolicy\", \u0026opsgenie.AlertPolicyArgs{\n\t\t\tTeamId:            testTeam.ID(),\n\t\t\tPolicyDescription: pulumi.String(\"This is sample policy\"),\n\t\t\tMessage:           pulumi.String(\"{{message}}\"),\n\t\t\tFilters: AlertPolicyFilterArray{\n\t\t\t\tnil,\n\t\t\t},\n\t\t\tTimeRestrictions: AlertPolicyTimeRestrictionArray{\n\t\t\t\t\u0026AlertPolicyTimeRestrictionArgs{\n\t\t\t\t\tType: pulumi.String(\"weekday-and-time-of-day\"),\n\t\t\t\t\tRestrictions: AlertPolicyTimeRestrictionRestrictionArray{\n\t\t\t\t\t\t\u0026AlertPolicyTimeRestrictionRestrictionArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(7),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(0),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"sunday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(21),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t\t\u0026AlertPolicyTimeRestrictionRestrictionArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"tuesday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(7),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(0),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(22),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nAlert policies can be imported using the `team_id/policy_id`, e.g.\n\n```sh\n $ pulumi import opsgenie:index/alertPolicy:AlertPolicy test team_id/policy_id`\n```\n\n You can import global polices using only policy identifier\n\n```sh\n $ pulumi import opsgenie:index/alertPolicy:AlertPolicy test policy_id`\n```\n\n ",
+            "description": "Manages a Alert Policy within Opsgenie.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as opsgenie from \"@pulumi/opsgenie\";\n\nconst testTeam = new opsgenie.Team(\"testTeam\", {description: \"This team deals with all the things\"});\nconst testAlertPolicy = new opsgenie.AlertPolicy(\"testAlertPolicy\", {\n    teamId: testTeam.id,\n    policyDescription: \"This is sample policy\",\n    message: \"{{message}}\",\n    filters: [{}],\n    timeRestrictions: [{\n        type: \"weekday-and-time-of-day\",\n        restrictionList: [\n            {\n                endDay: \"monday\",\n                endHour: 7,\n                endMin: 0,\n                startDay: \"sunday\",\n                startHour: 21,\n                startMin: 0,\n            },\n            {\n                endDay: \"tuesday\",\n                endHour: 7,\n                endMin: 0,\n                startDay: \"monday\",\n                startHour: 22,\n                startMin: 0,\n            },\n        ],\n    }],\n});\n```\n```python\nimport pulumi\nimport pulumi_opsgenie as opsgenie\n\ntest_team = opsgenie.Team(\"testTeam\", description=\"This team deals with all the things\")\ntest_alert_policy = opsgenie.AlertPolicy(\"testAlertPolicy\",\n    team_id=test_team.id,\n    policy_description=\"This is sample policy\",\n    message=\"{{message}}\",\n    filters=[opsgenie.AlertPolicyFilterArgs()],\n    time_restrictions=[opsgenie.AlertPolicyTimeRestrictionArgs(\n        type=\"weekday-and-time-of-day\",\n        restriction_list=[\n            opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(\n                end_day=\"monday\",\n                end_hour=7,\n                end_min=0,\n                start_day=\"sunday\",\n                start_hour=21,\n                start_min=0,\n            ),\n            opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(\n                end_day=\"tuesday\",\n                end_hour=7,\n                end_min=0,\n                start_day=\"monday\",\n                start_hour=22,\n                start_min=0,\n            ),\n        ],\n    )])\n```\n```csharp\nusing Pulumi;\nusing Opsgenie = Pulumi.Opsgenie;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var testTeam = new Opsgenie.Team(\"testTeam\", new Opsgenie.TeamArgs\n        {\n            Description = \"This team deals with all the things\",\n        });\n        var testAlertPolicy = new Opsgenie.AlertPolicy(\"testAlertPolicy\", new Opsgenie.AlertPolicyArgs\n        {\n            TeamId = testTeam.Id,\n            PolicyDescription = \"This is sample policy\",\n            Message = \"{{message}}\",\n            Filters = \n            {\n                ,\n            },\n            TimeRestrictions = \n            {\n                new Opsgenie.Inputs.AlertPolicyTimeRestrictionArgs\n                {\n                    Type = \"weekday-and-time-of-day\",\n                    RestrictionList = \n                    {\n                        new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionListArgs\n                        {\n                            EndDay = \"monday\",\n                            EndHour = 7,\n                            EndMin = 0,\n                            StartDay = \"sunday\",\n                            StartHour = 21,\n                            StartMin = 0,\n                        },\n                        new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionListArgs\n                        {\n                            EndDay = \"tuesday\",\n                            EndHour = 7,\n                            EndMin = 0,\n                            StartDay = \"monday\",\n                            StartHour = 22,\n                            StartMin = 0,\n                        },\n                    },\n                },\n            },\n        });\n    }\n\n}\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-opsgenie/sdk/go/opsgenie\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestTeam, err := opsgenie.NewTeam(ctx, \"testTeam\", \u0026opsgenie.TeamArgs{\n\t\t\tDescription: pulumi.String(\"This team deals with all the things\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = opsgenie.NewAlertPolicy(ctx, \"testAlertPolicy\", \u0026opsgenie.AlertPolicyArgs{\n\t\t\tTeamId:            testTeam.ID(),\n\t\t\tPolicyDescription: pulumi.String(\"This is sample policy\"),\n\t\t\tMessage:           pulumi.String(\"{{message}}\"),\n\t\t\tFilters: AlertPolicyFilterArray{\n\t\t\t\tnil,\n\t\t\t},\n\t\t\tTimeRestrictions: AlertPolicyTimeRestrictionArray{\n\t\t\t\t\u0026AlertPolicyTimeRestrictionArgs{\n\t\t\t\t\tType: pulumi.String(\"weekday-and-time-of-day\"),\n\t\t\t\t\tRestrictionList: AlertPolicyTimeRestrictionRestrictionListArray{\n\t\t\t\t\t\t\u0026AlertPolicyTimeRestrictionRestrictionListArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(7),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(0),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"sunday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(21),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t\t\u0026AlertPolicyTimeRestrictionRestrictionListArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"tuesday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(7),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(0),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(22),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nAlert policies can be imported using the `team_id/policy_id`, e.g.\n\n```sh\n $ pulumi import opsgenie:index/alertPolicy:AlertPolicy test team_id/policy_id`\n```\n\n You can import global polices using only policy identifier\n\n```sh\n $ pulumi import opsgenie:index/alertPolicy:AlertPolicy test policy_id`\n```\n\n ",
             "properties": {
                 "actions": {
                     "type": "array",
@@ -5089,7 +5285,7 @@
             }
         },
         "opsgenie:index/teamRoutingRule:TeamRoutingRule": {
-            "description": "Manages a Team Routing Rule within Opsgenie.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as opsgenie from \"@pulumi/opsgenie\";\n\nconst testSchedule = new opsgenie.Schedule(\"test\", {\n    description: \"schedule test\",\n    enabled: false,\n    timezone: \"Europe/Rome\",\n});\nconst testTeam = new opsgenie.Team(\"test\", {\n    description: \"This team deals with all the things\",\n});\nconst testTeamRoutingRule = new opsgenie.TeamRoutingRule(\"test\", {\n    criterias: [{\n        conditions: [{\n            expectedValue: \"expected1\",\n            field: \"message\",\n            not: false,\n            operation: \"contains\",\n        }],\n        type: \"match-any-condition\",\n    }],\n    notifies: [{\n        name: testSchedule.name,\n        type: \"schedule\",\n    }],\n    order: 0,\n    teamId: testTeam.id,\n    timeRestrictions: [{\n        restrictions: [{\n            endDay: \"tuesday\",\n            endHour: 18,\n            endMin: 30,\n            startDay: \"monday\",\n            startHour: 8,\n            startMin: 0,\n        }],\n        type: \"weekday-and-time-of-day\",\n    }],\n    timezone: \"America/Los_Angeles\",\n});\n```\n```python\nimport pulumi\nimport pulumi_opsgenie as opsgenie\n\ntest_schedule = opsgenie.Schedule(\"testSchedule\",\n    description=\"schedule test\",\n    enabled=False,\n    timezone=\"Europe/Rome\")\ntest_team = opsgenie.Team(\"testTeam\", description=\"This team deals with all the things\")\ntest_team_routing_rule = opsgenie.TeamRoutingRule(\"testTeamRoutingRule\",\n    criterias=[opsgenie.TeamRoutingRuleCriteriaArgs(\n        conditions=[opsgenie.TeamRoutingRuleCriteriaConditionArgs(\n            expected_value=\"expected1\",\n            field=\"message\",\n            not_=False,\n            operation=\"contains\",\n        )],\n        type=\"match-any-condition\",\n    )],\n    notifies=[opsgenie.TeamRoutingRuleNotifyArgs(\n        name=test_schedule.name,\n        type=\"schedule\",\n    )],\n    order=0,\n    team_id=test_team.id,\n    time_restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionArgs(\n        restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionArgs(\n            end_day=\"tuesday\",\n            end_hour=18,\n            end_min=30,\n            start_day=\"monday\",\n            start_hour=8,\n            start_min=0,\n        )],\n        type=\"weekday-and-time-of-day\",\n    )],\n    timezone=\"America/Los_Angeles\")\n```\n```csharp\nusing Pulumi;\nusing Opsgenie = Pulumi.Opsgenie;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var testSchedule = new Opsgenie.Schedule(\"testSchedule\", new Opsgenie.ScheduleArgs\n        {\n            Description = \"schedule test\",\n            Enabled = false,\n            Timezone = \"Europe/Rome\",\n        });\n        var testTeam = new Opsgenie.Team(\"testTeam\", new Opsgenie.TeamArgs\n        {\n            Description = \"This team deals with all the things\",\n        });\n        var testTeamRoutingRule = new Opsgenie.TeamRoutingRule(\"testTeamRoutingRule\", new Opsgenie.TeamRoutingRuleArgs\n        {\n            Criterias = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleCriteriaArgs\n                {\n                    Conditions = \n                    {\n                        new Opsgenie.Inputs.TeamRoutingRuleCriteriaConditionArgs\n                        {\n                            ExpectedValue = \"expected1\",\n                            Field = \"message\",\n                            Not = false,\n                            Operation = \"contains\",\n                        },\n                    },\n                    Type = \"match-any-condition\",\n                },\n            },\n            Notifies = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleNotifyArgs\n                {\n                    Name = testSchedule.Name,\n                    Type = \"schedule\",\n                },\n            },\n            Order = 0,\n            TeamId = testTeam.Id,\n            TimeRestrictions = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionArgs\n                {\n                    Restrictions = \n                    {\n                        new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionRestrictionArgs\n                        {\n                            EndDay = \"tuesday\",\n                            EndHour = 18,\n                            EndMin = 30,\n                            StartDay = \"monday\",\n                            StartHour = 8,\n                            StartMin = 0,\n                        },\n                    },\n                    Type = \"weekday-and-time-of-day\",\n                },\n            },\n            Timezone = \"America/Los_Angeles\",\n        });\n    }\n\n}\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-opsgenie/sdk/go/opsgenie\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestSchedule, err := opsgenie.NewSchedule(ctx, \"testSchedule\", \u0026opsgenie.ScheduleArgs{\n\t\t\tDescription: pulumi.String(\"schedule test\"),\n\t\t\tEnabled:     pulumi.Bool(false),\n\t\t\tTimezone:    pulumi.String(\"Europe/Rome\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\ttestTeam, err := opsgenie.NewTeam(ctx, \"testTeam\", \u0026opsgenie.TeamArgs{\n\t\t\tDescription: pulumi.String(\"This team deals with all the things\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = opsgenie.NewTeamRoutingRule(ctx, \"testTeamRoutingRule\", \u0026opsgenie.TeamRoutingRuleArgs{\n\t\t\tCriterias: TeamRoutingRuleCriteriaArray{\n\t\t\t\t\u0026TeamRoutingRuleCriteriaArgs{\n\t\t\t\t\tConditions: TeamRoutingRuleCriteriaConditionArray{\n\t\t\t\t\t\t\u0026TeamRoutingRuleCriteriaConditionArgs{\n\t\t\t\t\t\t\tExpectedValue: pulumi.String(\"expected1\"),\n\t\t\t\t\t\t\tField:         pulumi.String(\"message\"),\n\t\t\t\t\t\t\tNot:           pulumi.Bool(false),\n\t\t\t\t\t\t\tOperation:     pulumi.String(\"contains\"),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tType: pulumi.String(\"match-any-condition\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tNotifies: TeamRoutingRuleNotifyArray{\n\t\t\t\t\u0026TeamRoutingRuleNotifyArgs{\n\t\t\t\t\tName: testSchedule.Name,\n\t\t\t\t\tType: pulumi.String(\"schedule\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tOrder:  pulumi.Int(0),\n\t\t\tTeamId: testTeam.ID(),\n\t\t\tTimeRestrictions: TeamRoutingRuleTimeRestrictionArray{\n\t\t\t\t\u0026TeamRoutingRuleTimeRestrictionArgs{\n\t\t\t\t\tRestrictions: TeamRoutingRuleTimeRestrictionRestrictionArray{\n\t\t\t\t\t\t\u0026TeamRoutingRuleTimeRestrictionRestrictionArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"tuesday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(18),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(30),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(8),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tType: pulumi.String(\"weekday-and-time-of-day\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tTimezone: pulumi.String(\"America/Los_Angeles\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nTeam Routing Rules can be imported using the `team_id/routing_rule_id`, e.g.\n\n```sh\n $ pulumi import opsgenie:index/teamRoutingRule:TeamRoutingRule ruletest team_id/routing_rule_id`\n```\n\n ",
+            "description": "Manages a Team Routing Rule within Opsgenie.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as opsgenie from \"@pulumi/opsgenie\";\n\nconst testSchedule = new opsgenie.Schedule(\"test\", {\n    description: \"schedule test\",\n    enabled: false,\n    timezone: \"Europe/Rome\",\n});\nconst testTeam = new opsgenie.Team(\"test\", {\n    description: \"This team deals with all the things\",\n});\nconst testTeamRoutingRule = new opsgenie.TeamRoutingRule(\"test\", {\n    criterias: [{\n        conditions: [{\n            expectedValue: \"expected1\",\n            field: \"message\",\n            not: false,\n            operation: \"contains\",\n        }],\n        type: \"match-any-condition\",\n    }],\n    notifies: [{\n        name: testSchedule.name,\n        type: \"schedule\",\n    }],\n    order: 0,\n    teamId: testTeam.id,\n    timeRestrictions: [{\n        restrictionList: [{\n            endDay: \"tuesday\",\n            endHour: 18,\n            endMin: 30,\n            startDay: \"monday\",\n            startHour: 8,\n            startMin: 0,\n        }],\n        type: \"weekday-and-time-of-day\",\n    }],\n    timezone: \"America/Los_Angeles\",\n});\n```\n```python\nimport pulumi\nimport pulumi_opsgenie as opsgenie\n\ntest_schedule = opsgenie.Schedule(\"testSchedule\",\n    description=\"schedule test\",\n    enabled=False,\n    timezone=\"Europe/Rome\")\ntest_team = opsgenie.Team(\"testTeam\", description=\"This team deals with all the things\")\ntest_team_routing_rule = opsgenie.TeamRoutingRule(\"testTeamRoutingRule\",\n    criterias=[opsgenie.TeamRoutingRuleCriteriaArgs(\n        conditions=[opsgenie.TeamRoutingRuleCriteriaConditionArgs(\n            expected_value=\"expected1\",\n            field=\"message\",\n            not_=False,\n            operation=\"contains\",\n        )],\n        type=\"match-any-condition\",\n    )],\n    notifies=[opsgenie.TeamRoutingRuleNotifyArgs(\n        name=test_schedule.name,\n        type=\"schedule\",\n    )],\n    order=0,\n    team_id=test_team.id,\n    time_restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionArgs(\n        restriction_list=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionListArgs(\n            end_day=\"tuesday\",\n            end_hour=18,\n            end_min=30,\n            start_day=\"monday\",\n            start_hour=8,\n            start_min=0,\n        )],\n        type=\"weekday-and-time-of-day\",\n    )],\n    timezone=\"America/Los_Angeles\")\n```\n```csharp\nusing Pulumi;\nusing Opsgenie = Pulumi.Opsgenie;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var testSchedule = new Opsgenie.Schedule(\"testSchedule\", new Opsgenie.ScheduleArgs\n        {\n            Description = \"schedule test\",\n            Enabled = false,\n            Timezone = \"Europe/Rome\",\n        });\n        var testTeam = new Opsgenie.Team(\"testTeam\", new Opsgenie.TeamArgs\n        {\n            Description = \"This team deals with all the things\",\n        });\n        var testTeamRoutingRule = new Opsgenie.TeamRoutingRule(\"testTeamRoutingRule\", new Opsgenie.TeamRoutingRuleArgs\n        {\n            Criterias = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleCriteriaArgs\n                {\n                    Conditions = \n                    {\n                        new Opsgenie.Inputs.TeamRoutingRuleCriteriaConditionArgs\n                        {\n                            ExpectedValue = \"expected1\",\n                            Field = \"message\",\n                            Not = false,\n                            Operation = \"contains\",\n                        },\n                    },\n                    Type = \"match-any-condition\",\n                },\n            },\n            Notifies = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleNotifyArgs\n                {\n                    Name = testSchedule.Name,\n                    Type = \"schedule\",\n                },\n            },\n            Order = 0,\n            TeamId = testTeam.Id,\n            TimeRestrictions = \n            {\n                new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionArgs\n                {\n                    RestrictionList = \n                    {\n                        new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionRestrictionListArgs\n                        {\n                            EndDay = \"tuesday\",\n                            EndHour = 18,\n                            EndMin = 30,\n                            StartDay = \"monday\",\n                            StartHour = 8,\n                            StartMin = 0,\n                        },\n                    },\n                    Type = \"weekday-and-time-of-day\",\n                },\n            },\n            Timezone = \"America/Los_Angeles\",\n        });\n    }\n\n}\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-opsgenie/sdk/go/opsgenie\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestSchedule, err := opsgenie.NewSchedule(ctx, \"testSchedule\", \u0026opsgenie.ScheduleArgs{\n\t\t\tDescription: pulumi.String(\"schedule test\"),\n\t\t\tEnabled:     pulumi.Bool(false),\n\t\t\tTimezone:    pulumi.String(\"Europe/Rome\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\ttestTeam, err := opsgenie.NewTeam(ctx, \"testTeam\", \u0026opsgenie.TeamArgs{\n\t\t\tDescription: pulumi.String(\"This team deals with all the things\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = opsgenie.NewTeamRoutingRule(ctx, \"testTeamRoutingRule\", \u0026opsgenie.TeamRoutingRuleArgs{\n\t\t\tCriterias: TeamRoutingRuleCriteriaArray{\n\t\t\t\t\u0026TeamRoutingRuleCriteriaArgs{\n\t\t\t\t\tConditions: TeamRoutingRuleCriteriaConditionArray{\n\t\t\t\t\t\t\u0026TeamRoutingRuleCriteriaConditionArgs{\n\t\t\t\t\t\t\tExpectedValue: pulumi.String(\"expected1\"),\n\t\t\t\t\t\t\tField:         pulumi.String(\"message\"),\n\t\t\t\t\t\t\tNot:           pulumi.Bool(false),\n\t\t\t\t\t\t\tOperation:     pulumi.String(\"contains\"),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tType: pulumi.String(\"match-any-condition\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tNotifies: TeamRoutingRuleNotifyArray{\n\t\t\t\t\u0026TeamRoutingRuleNotifyArgs{\n\t\t\t\t\tName: testSchedule.Name,\n\t\t\t\t\tType: pulumi.String(\"schedule\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tOrder:  pulumi.Int(0),\n\t\t\tTeamId: testTeam.ID(),\n\t\t\tTimeRestrictions: TeamRoutingRuleTimeRestrictionArray{\n\t\t\t\t\u0026TeamRoutingRuleTimeRestrictionArgs{\n\t\t\t\t\tRestrictionList: TeamRoutingRuleTimeRestrictionRestrictionListArray{\n\t\t\t\t\t\t\u0026TeamRoutingRuleTimeRestrictionRestrictionListArgs{\n\t\t\t\t\t\t\tEndDay:    pulumi.String(\"tuesday\"),\n\t\t\t\t\t\t\tEndHour:   pulumi.Int(18),\n\t\t\t\t\t\t\tEndMin:    pulumi.Int(30),\n\t\t\t\t\t\t\tStartDay:  pulumi.String(\"monday\"),\n\t\t\t\t\t\t\tStartHour: pulumi.Int(8),\n\t\t\t\t\t\t\tStartMin:  pulumi.Int(0),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tType: pulumi.String(\"weekday-and-time-of-day\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tTimezone: pulumi.String(\"America/Los_Angeles\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nTeam Routing Rules can be imported using the `team_id/routing_rule_id`, e.g.\n\n```sh\n $ pulumi import opsgenie:index/teamRoutingRule:TeamRoutingRule ruletest team_id/routing_rule_id`\n```\n\n ",
             "properties": {
                 "criterias": {
                     "type": "array",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -95,11 +95,11 @@ func Provider() tfbridge.ProviderInfo {
 					"time_restriction": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{
-								// Similar to ScheduleRotation below, we have both a `restrictions` and a `restriction`
-								// parameter so we need to explicitly declare both here to avoid overwriting one field
-								// with the other.
+								// there is both a restriction and restrictions parameters so we want to stop
+								// the bridge automatically pluralising the values to prevent any issues
+								// See: https://github.com/pulumi/pulumi-opsgenie/issues/57
 								"restriction":  {Name: "restriction"},
-								"restrictions": {Name: "restrictions"},
+								"restrictions": {Name: "restrictionList"},
 							},
 						},
 					},
@@ -120,10 +120,11 @@ func Provider() tfbridge.ProviderInfo {
 					"time_restriction": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{
-								// Again, we have both a `restrictions` and a `restriction` parameter so we need
-								// to explicitly declare both here to avoid overwriting one field with the other.
+								// there is both a restriction and restrictions parameters so we want to stop
+								// the bridge automatically pluralising the values to prevent any issues
+								// See: https://github.com/pulumi/pulumi-opsgenie/issues/57
 								"restriction":  {Name: "restriction"},
-								"restrictions": {Name: "restrictions"},
+								"restrictions": {Name: "restrictionList"},
 							},
 						},
 					},
@@ -158,8 +159,9 @@ func Provider() tfbridge.ProviderInfo {
 							Fields: map[string]*tfbridge.SchemaInfo{
 								// there is both a restriction and restrictions parameters so we want to stop
 								// the bridge automatically pluralising the values to prevent any issues
+								// See: https://github.com/pulumi/pulumi-opsgenie/issues/57
 								"restriction":  {Name: "restriction"},
-								"restrictions": {Name: "restrictions"},
+								"restrictions": {Name: "restrictionList"},
 							},
 						},
 					},
@@ -173,6 +175,19 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"opsgenie_alert_policy": {
 				Tok: makeResource(mainMod, "AlertPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"time_restriction": {
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								// there is both a restriction and restrictions parameter so we want to stop
+								// the bridge automatically pluralising the values to prevent any issues
+								// See: https://github.com/pulumi/pulumi-opsgenie/issues/57
+								"restriction":  {Name: "restriction"},
+								"restrictions": {Name: "restrictionList"},
+							},
+						},
+					},
+				},
 			},
 			"opsgenie_service_incident_rule": {
 				Tok: makeResource(mainMod, "ServiceIncidentRule"),

--- a/sdk/dotnet/AlertPolicy.cs
+++ b/sdk/dotnet/AlertPolicy.cs
@@ -40,9 +40,9 @@ namespace Pulumi.Opsgenie
     ///                 new Opsgenie.Inputs.AlertPolicyTimeRestrictionArgs
     ///                 {
     ///                     Type = "weekday-and-time-of-day",
-    ///                     Restrictions = 
+    ///                     RestrictionList = 
     ///                     {
-    ///                         new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionArgs
+    ///                         new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionListArgs
     ///                         {
     ///                             EndDay = "monday",
     ///                             EndHour = 7,
@@ -51,7 +51,7 @@ namespace Pulumi.Opsgenie
     ///                             StartHour = 21,
     ///                             StartMin = 0,
     ///                         },
-    ///                         new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionArgs
+    ///                         new Opsgenie.Inputs.AlertPolicyTimeRestrictionRestrictionListArgs
     ///                         {
     ///                             EndDay = "tuesday",
     ///                             EndHour = 7,

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionArgs.cs
@@ -12,16 +12,28 @@ namespace Pulumi.Opsgenie.Inputs
 
     public sealed class AlertPolicyTimeRestrictionArgs : Pulumi.ResourceArgs
     {
-        [Input("restrictions")]
-        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs>? _restrictions;
+        [Input("restriction")]
+        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs>? _restriction;
+
+        /// <summary>
+        /// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        /// </summary>
+        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs> Restriction
+        {
+            get => _restriction ?? (_restriction = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs>());
+            set => _restriction = value;
+        }
+
+        [Input("restrictionList")]
+        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListArgs>? _restrictionList;
 
         /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs> Restrictions
+        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionGetArgs.cs
@@ -12,16 +12,28 @@ namespace Pulumi.Opsgenie.Inputs
 
     public sealed class AlertPolicyTimeRestrictionGetArgs : Pulumi.ResourceArgs
     {
-        [Input("restrictions")]
-        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs>? _restrictions;
+        [Input("restriction")]
+        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs>? _restriction;
+
+        /// <summary>
+        /// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        /// </summary>
+        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs> Restriction
+        {
+            get => _restriction ?? (_restriction = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs>());
+            set => _restriction = value;
+        }
+
+        [Input("restrictionList")]
+        private InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListGetArgs>? _restrictionList;
 
         /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs> Restrictions
+        public InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListGetArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionGetArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.AlertPolicyTimeRestrictionRestrictionListGetArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionArgs.cs
@@ -13,12 +13,6 @@ namespace Pulumi.Opsgenie.Inputs
     public sealed class AlertPolicyTimeRestrictionRestrictionArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Ending day of restriction (eg. `wednesday`)
-        /// </summary>
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
-        /// <summary>
         /// Ending hour of restriction.
         /// </summary>
         [Input("endHour", required: true)]
@@ -29,12 +23,6 @@ namespace Pulumi.Opsgenie.Inputs
         /// </summary>
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
-
-        /// <summary>
-        /// Starting day of restriction (eg. `monday`)
-        /// </summary>
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
 
         /// <summary>
         /// Starting hour of restriction.

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionGetArgs.cs
@@ -13,12 +13,6 @@ namespace Pulumi.Opsgenie.Inputs
     public sealed class AlertPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Ending day of restriction (eg. `wednesday`)
-        /// </summary>
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
-        /// <summary>
         /// Ending hour of restriction.
         /// </summary>
         [Input("endHour", required: true)]
@@ -29,12 +23,6 @@ namespace Pulumi.Opsgenie.Inputs
         /// </summary>
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
-
-        /// <summary>
-        /// Starting day of restriction (eg. `monday`)
-        /// </summary>
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
 
         /// <summary>
         /// Starting hour of restriction.

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionListArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionListArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class AlertPolicyTimeRestrictionRestrictionListArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -25,6 +31,12 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
         /// Starting hour of restriction.
         /// </summary>
         [Input("startHour", required: true)]
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public AlertPolicyTimeRestrictionRestrictionListArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionListGetArgs.cs
+++ b/sdk/dotnet/Inputs/AlertPolicyTimeRestrictionRestrictionListGetArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class AlertPolicyTimeRestrictionRestrictionListGetArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -25,6 +31,12 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
         /// Starting hour of restriction.
         /// </summary>
         [Input("startHour", required: true)]
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public AlertPolicyTimeRestrictionRestrictionListGetArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionArgs.cs
@@ -24,16 +24,16 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionArgs>? _restrictions;
+        [Input("restrictionList")]
+        private InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListArgs>? _restrictionList;
 
         /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionArgs> Restrictions
+        public InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionGetArgs.cs
@@ -24,16 +24,16 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionGetArgs>? _restrictions;
+        [Input("restrictionList")]
+        private InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListGetArgs>? _restrictionList;
 
         /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionGetArgs> Restrictions
+        public InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListGetArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionGetArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.NotificationPolicyTimeRestrictionRestrictionListGetArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionArgs.cs
@@ -13,12 +13,6 @@ namespace Pulumi.Opsgenie.Inputs
     public sealed class NotificationPolicyTimeRestrictionRestrictionArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Ending day of restriction (eg. `wednesday`)
-        /// </summary>
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
-        /// <summary>
         /// Ending hour of restriction.
         /// </summary>
         [Input("endHour", required: true)]
@@ -29,12 +23,6 @@ namespace Pulumi.Opsgenie.Inputs
         /// </summary>
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
-
-        /// <summary>
-        /// Starting day of restriction (eg. `monday`)
-        /// </summary>
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
 
         /// <summary>
         /// Starting hour of restriction.

--- a/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionListArgs.cs
+++ b/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionListArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class NotificationPolicyTimeRestrictionRestrictionListArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -25,6 +31,12 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
         /// Starting hour of restriction.
         /// </summary>
         [Input("startHour", required: true)]
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public NotificationPolicyTimeRestrictionRestrictionListArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionListGetArgs.cs
+++ b/sdk/dotnet/Inputs/NotificationPolicyTimeRestrictionRestrictionListGetArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class NotificationPolicyTimeRestrictionRestrictionListGetArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -25,6 +31,12 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
         /// Starting hour of restriction.
         /// </summary>
         [Input("startHour", required: true)]
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public NotificationPolicyTimeRestrictionRestrictionListGetArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionArgs.cs
@@ -24,16 +24,16 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionArgs>? _restrictions;
+        [Input("restrictionList")]
+        private InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListArgs>? _restrictionList;
 
         /// <summary>
         /// It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         /// </summary>
-        public InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionArgs> Restrictions
+        public InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionGetArgs.cs
@@ -24,16 +24,16 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionGetArgs>? _restrictions;
+        [Input("restrictionList")]
+        private InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListGetArgs>? _restrictionList;
 
         /// <summary>
         /// It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         /// </summary>
-        public InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionGetArgs> Restrictions
+        public InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListGetArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionGetArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.ScheduleRotationTimeRestrictionRestrictionListGetArgs>());
+            set => _restrictionList = value;
         }
 
         /// <summary>

--- a/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionArgs.cs
@@ -13,12 +13,6 @@ namespace Pulumi.Opsgenie.Inputs
     public sealed class ScheduleRotationTimeRestrictionRestrictionArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Value of the day that frame will end.
-        /// </summary>
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
-        /// <summary>
         /// Value of the hour that frame will end.
         /// </summary>
         [Input("endHour", required: true)]
@@ -31,13 +25,7 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
-        /// Value of the day that frame will start.
-        /// </summary>
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
-
-        /// <summary>
-        /// Value of the hour that frame will start
+        /// Value of the hour that frame will start.
         /// </summary>
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;

--- a/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionListArgs.cs
+++ b/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionListArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class ScheduleRotationTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class ScheduleRotationTimeRestrictionRestrictionListArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Value of the day that frame will end.
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Value of the hour that frame will end.
         /// </summary>
@@ -25,7 +31,13 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
-        /// Value of the hour that frame will start.
+        /// Value of the day that frame will start.
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
+        /// Value of the hour that frame will start
         /// </summary>
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public ScheduleRotationTimeRestrictionRestrictionGetArgs()
+        public ScheduleRotationTimeRestrictionRestrictionListArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionListGetArgs.cs
+++ b/sdk/dotnet/Inputs/ScheduleRotationTimeRestrictionRestrictionListGetArgs.cs
@@ -10,8 +10,14 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class ScheduleRotationTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class ScheduleRotationTimeRestrictionRestrictionListGetArgs : Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Value of the day that frame will end.
+        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         /// <summary>
         /// Value of the hour that frame will end.
         /// </summary>
@@ -25,7 +31,13 @@ namespace Pulumi.Opsgenie.Inputs
         public Input<int> EndMin { get; set; } = null!;
 
         /// <summary>
-        /// Value of the hour that frame will start.
+        /// Value of the day that frame will start.
+        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
+        /// <summary>
+        /// Value of the hour that frame will start
         /// </summary>
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;
@@ -36,7 +48,7 @@ namespace Pulumi.Opsgenie.Inputs
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public ScheduleRotationTimeRestrictionRestrictionGetArgs()
+        public ScheduleRotationTimeRestrictionRestrictionListGetArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionArgs.cs
@@ -20,12 +20,12 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionArgs>? _restrictions;
-        public InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionArgs> Restrictions
+        [Input("restrictionList")]
+        private InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListArgs>? _restrictionList;
+        public InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListArgs>());
+            set => _restrictionList = value;
         }
 
         [Input("type", required: true)]

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionGetArgs.cs
@@ -20,12 +20,12 @@ namespace Pulumi.Opsgenie.Inputs
             set => _restriction = value;
         }
 
-        [Input("restrictions")]
-        private InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionGetArgs>? _restrictions;
-        public InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionGetArgs> Restrictions
+        [Input("restrictionList")]
+        private InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListGetArgs>? _restrictionList;
+        public InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListGetArgs> RestrictionList
         {
-            get => _restrictions ?? (_restrictions = new InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionGetArgs>());
-            set => _restrictions = value;
+            get => _restrictionList ?? (_restrictionList = new InputList<Inputs.TeamRoutingRuleTimeRestrictionRestrictionListGetArgs>());
+            set => _restrictionList = value;
         }
 
         [Input("type", required: true)]

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionArgs.cs
@@ -12,17 +12,11 @@ namespace Pulumi.Opsgenie.Inputs
 
     public sealed class TeamRoutingRuleTimeRestrictionRestrictionArgs : Pulumi.ResourceArgs
     {
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
         [Input("endHour", required: true)]
         public Input<int> EndHour { get; set; } = null!;
 
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
-
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
 
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionGetArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionGetArgs.cs
@@ -12,17 +12,11 @@ namespace Pulumi.Opsgenie.Inputs
 
     public sealed class TeamRoutingRuleTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
     {
-        [Input("endDay", required: true)]
-        public Input<string> EndDay { get; set; } = null!;
-
         [Input("endHour", required: true)]
         public Input<int> EndHour { get; set; } = null!;
 
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
-
-        [Input("startDay", required: true)]
-        public Input<string> StartDay { get; set; } = null!;
 
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionListArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionListArgs.cs
@@ -10,33 +10,27 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class TeamRoutingRuleTimeRestrictionRestrictionListArgs : Pulumi.ResourceArgs
     {
-        /// <summary>
-        /// Ending hour of restriction.
-        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         [Input("endHour", required: true)]
         public Input<int> EndHour { get; set; } = null!;
 
-        /// <summary>
-        /// Ending minute of restriction on defined `end_hour`
-        /// </summary>
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
 
-        /// <summary>
-        /// Starting hour of restriction.
-        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;
 
-        /// <summary>
-        /// Staring minute of restriction on defined `start_hour`
-        /// </summary>
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public TeamRoutingRuleTimeRestrictionRestrictionListArgs()
         {
         }
     }

--- a/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionListGetArgs.cs
+++ b/sdk/dotnet/Inputs/TeamRoutingRuleTimeRestrictionRestrictionListGetArgs.cs
@@ -10,33 +10,27 @@ using Pulumi.Serialization;
 namespace Pulumi.Opsgenie.Inputs
 {
 
-    public sealed class NotificationPolicyTimeRestrictionRestrictionGetArgs : Pulumi.ResourceArgs
+    public sealed class TeamRoutingRuleTimeRestrictionRestrictionListGetArgs : Pulumi.ResourceArgs
     {
-        /// <summary>
-        /// Ending hour of restriction.
-        /// </summary>
+        [Input("endDay", required: true)]
+        public Input<string> EndDay { get; set; } = null!;
+
         [Input("endHour", required: true)]
         public Input<int> EndHour { get; set; } = null!;
 
-        /// <summary>
-        /// Ending minute of restriction on defined `end_hour`
-        /// </summary>
         [Input("endMin", required: true)]
         public Input<int> EndMin { get; set; } = null!;
 
-        /// <summary>
-        /// Starting hour of restriction.
-        /// </summary>
+        [Input("startDay", required: true)]
+        public Input<string> StartDay { get; set; } = null!;
+
         [Input("startHour", required: true)]
         public Input<int> StartHour { get; set; } = null!;
 
-        /// <summary>
-        /// Staring minute of restriction on defined `start_hour`
-        /// </summary>
         [Input("startMin", required: true)]
         public Input<int> StartMin { get; set; } = null!;
 
-        public NotificationPolicyTimeRestrictionRestrictionGetArgs()
+        public TeamRoutingRuleTimeRestrictionRestrictionListGetArgs()
         {
         }
     }

--- a/sdk/dotnet/Outputs/AlertPolicyTimeRestriction.cs
+++ b/sdk/dotnet/Outputs/AlertPolicyTimeRestriction.cs
@@ -14,9 +14,13 @@ namespace Pulumi.Opsgenie.Outputs
     public sealed class AlertPolicyTimeRestriction
     {
         /// <summary>
+        /// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        /// </summary>
+        public readonly ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestriction> Restriction;
+        /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public readonly ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestriction> Restrictions;
+        public readonly ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestrictionList> RestrictionList;
         /// <summary>
         /// Type of responder. Acceptable values are: `user` or `team`
         /// </summary>
@@ -24,11 +28,14 @@ namespace Pulumi.Opsgenie.Outputs
 
         [OutputConstructor]
         private AlertPolicyTimeRestriction(
-            ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestriction> restrictions,
+            ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestriction> restriction,
+
+            ImmutableArray<Outputs.AlertPolicyTimeRestrictionRestrictionList> restrictionList,
 
             string type)
         {
-            Restrictions = restrictions;
+            Restriction = restriction;
+            RestrictionList = restrictionList;
             Type = type;
         }
     }

--- a/sdk/dotnet/Outputs/AlertPolicyTimeRestrictionRestrictionList.cs
+++ b/sdk/dotnet/Outputs/AlertPolicyTimeRestrictionRestrictionList.cs
@@ -11,8 +11,12 @@ namespace Pulumi.Opsgenie.Outputs
 {
 
     [OutputType]
-    public sealed class AlertPolicyTimeRestrictionRestriction
+    public sealed class AlertPolicyTimeRestrictionRestrictionList
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        public readonly string EndDay;
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -21,6 +25,10 @@ namespace Pulumi.Opsgenie.Outputs
         /// Ending minute of restriction on defined `end_hour`
         /// </summary>
         public readonly int EndMin;
+        /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        public readonly string StartDay;
         /// <summary>
         /// Starting hour of restriction.
         /// </summary>
@@ -31,17 +39,23 @@ namespace Pulumi.Opsgenie.Outputs
         public readonly int StartMin;
 
         [OutputConstructor]
-        private AlertPolicyTimeRestrictionRestriction(
+        private AlertPolicyTimeRestrictionRestrictionList(
+            string endDay,
+
             int endHour,
 
             int endMin,
+
+            string startDay,
 
             int startHour,
 
             int startMin)
         {
+            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
+            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/NotificationPolicyTimeRestriction.cs
+++ b/sdk/dotnet/Outputs/NotificationPolicyTimeRestriction.cs
@@ -20,7 +20,7 @@ namespace Pulumi.Opsgenie.Outputs
         /// <summary>
         /// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         /// </summary>
-        public readonly ImmutableArray<Outputs.NotificationPolicyTimeRestrictionRestriction> Restrictions;
+        public readonly ImmutableArray<Outputs.NotificationPolicyTimeRestrictionRestrictionList> RestrictionList;
         /// <summary>
         /// Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
         /// </summary>
@@ -30,12 +30,12 @@ namespace Pulumi.Opsgenie.Outputs
         private NotificationPolicyTimeRestriction(
             ImmutableArray<Outputs.NotificationPolicyTimeRestrictionRestriction> restriction,
 
-            ImmutableArray<Outputs.NotificationPolicyTimeRestrictionRestriction> restrictions,
+            ImmutableArray<Outputs.NotificationPolicyTimeRestrictionRestrictionList> restrictionList,
 
             string type)
         {
             Restriction = restriction;
-            Restrictions = restrictions;
+            RestrictionList = restrictionList;
             Type = type;
         }
     }

--- a/sdk/dotnet/Outputs/NotificationPolicyTimeRestrictionRestriction.cs
+++ b/sdk/dotnet/Outputs/NotificationPolicyTimeRestrictionRestriction.cs
@@ -14,10 +14,6 @@ namespace Pulumi.Opsgenie.Outputs
     public sealed class NotificationPolicyTimeRestrictionRestriction
     {
         /// <summary>
-        /// Ending day of restriction (eg. `wednesday`)
-        /// </summary>
-        public readonly string EndDay;
-        /// <summary>
         /// Ending hour of restriction.
         /// </summary>
         public readonly int EndHour;
@@ -25,10 +21,6 @@ namespace Pulumi.Opsgenie.Outputs
         /// Ending minute of restriction on defined `end_hour`
         /// </summary>
         public readonly int EndMin;
-        /// <summary>
-        /// Starting day of restriction (eg. `monday`)
-        /// </summary>
-        public readonly string StartDay;
         /// <summary>
         /// Starting hour of restriction.
         /// </summary>
@@ -40,22 +32,16 @@ namespace Pulumi.Opsgenie.Outputs
 
         [OutputConstructor]
         private NotificationPolicyTimeRestrictionRestriction(
-            string endDay,
-
             int endHour,
 
             int endMin,
-
-            string startDay,
 
             int startHour,
 
             int startMin)
         {
-            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
-            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/NotificationPolicyTimeRestrictionRestrictionList.cs
+++ b/sdk/dotnet/Outputs/NotificationPolicyTimeRestrictionRestrictionList.cs
@@ -11,8 +11,12 @@ namespace Pulumi.Opsgenie.Outputs
 {
 
     [OutputType]
-    public sealed class AlertPolicyTimeRestrictionRestriction
+    public sealed class NotificationPolicyTimeRestrictionRestrictionList
     {
+        /// <summary>
+        /// Ending day of restriction (eg. `wednesday`)
+        /// </summary>
+        public readonly string EndDay;
         /// <summary>
         /// Ending hour of restriction.
         /// </summary>
@@ -21,6 +25,10 @@ namespace Pulumi.Opsgenie.Outputs
         /// Ending minute of restriction on defined `end_hour`
         /// </summary>
         public readonly int EndMin;
+        /// <summary>
+        /// Starting day of restriction (eg. `monday`)
+        /// </summary>
+        public readonly string StartDay;
         /// <summary>
         /// Starting hour of restriction.
         /// </summary>
@@ -31,17 +39,23 @@ namespace Pulumi.Opsgenie.Outputs
         public readonly int StartMin;
 
         [OutputConstructor]
-        private AlertPolicyTimeRestrictionRestriction(
+        private NotificationPolicyTimeRestrictionRestrictionList(
+            string endDay,
+
             int endHour,
 
             int endMin,
+
+            string startDay,
 
             int startHour,
 
             int startMin)
         {
+            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
+            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/ScheduleRotationTimeRestriction.cs
+++ b/sdk/dotnet/Outputs/ScheduleRotationTimeRestriction.cs
@@ -20,7 +20,7 @@ namespace Pulumi.Opsgenie.Outputs
         /// <summary>
         /// It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         /// </summary>
-        public readonly ImmutableArray<Outputs.ScheduleRotationTimeRestrictionRestriction> Restrictions;
+        public readonly ImmutableArray<Outputs.ScheduleRotationTimeRestrictionRestrictionList> RestrictionList;
         /// <summary>
         /// This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
         /// </summary>
@@ -30,12 +30,12 @@ namespace Pulumi.Opsgenie.Outputs
         private ScheduleRotationTimeRestriction(
             ImmutableArray<Outputs.ScheduleRotationTimeRestrictionRestriction> restriction,
 
-            ImmutableArray<Outputs.ScheduleRotationTimeRestrictionRestriction> restrictions,
+            ImmutableArray<Outputs.ScheduleRotationTimeRestrictionRestrictionList> restrictionList,
 
             string type)
         {
             Restriction = restriction;
-            Restrictions = restrictions;
+            RestrictionList = restrictionList;
             Type = type;
         }
     }

--- a/sdk/dotnet/Outputs/ScheduleRotationTimeRestrictionRestriction.cs
+++ b/sdk/dotnet/Outputs/ScheduleRotationTimeRestrictionRestriction.cs
@@ -14,10 +14,6 @@ namespace Pulumi.Opsgenie.Outputs
     public sealed class ScheduleRotationTimeRestrictionRestriction
     {
         /// <summary>
-        /// Value of the day that frame will end.
-        /// </summary>
-        public readonly string EndDay;
-        /// <summary>
         /// Value of the hour that frame will end.
         /// </summary>
         public readonly int EndHour;
@@ -26,11 +22,7 @@ namespace Pulumi.Opsgenie.Outputs
         /// </summary>
         public readonly int EndMin;
         /// <summary>
-        /// Value of the day that frame will start.
-        /// </summary>
-        public readonly string StartDay;
-        /// <summary>
-        /// Value of the hour that frame will start
+        /// Value of the hour that frame will start.
         /// </summary>
         public readonly int StartHour;
         /// <summary>
@@ -40,22 +32,16 @@ namespace Pulumi.Opsgenie.Outputs
 
         [OutputConstructor]
         private ScheduleRotationTimeRestrictionRestriction(
-            string endDay,
-
             int endHour,
 
             int endMin,
-
-            string startDay,
 
             int startHour,
 
             int startMin)
         {
-            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
-            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/ScheduleRotationTimeRestrictionRestrictionList.cs
+++ b/sdk/dotnet/Outputs/ScheduleRotationTimeRestrictionRestrictionList.cs
@@ -11,37 +11,51 @@ namespace Pulumi.Opsgenie.Outputs
 {
 
     [OutputType]
-    public sealed class AlertPolicyTimeRestrictionRestriction
+    public sealed class ScheduleRotationTimeRestrictionRestrictionList
     {
         /// <summary>
-        /// Ending hour of restriction.
+        /// Value of the day that frame will end.
+        /// </summary>
+        public readonly string EndDay;
+        /// <summary>
+        /// Value of the hour that frame will end.
         /// </summary>
         public readonly int EndHour;
         /// <summary>
-        /// Ending minute of restriction on defined `end_hour`
+        /// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
         /// </summary>
         public readonly int EndMin;
         /// <summary>
-        /// Starting hour of restriction.
+        /// Value of the day that frame will start.
+        /// </summary>
+        public readonly string StartDay;
+        /// <summary>
+        /// Value of the hour that frame will start
         /// </summary>
         public readonly int StartHour;
         /// <summary>
-        /// Staring minute of restriction on defined `start_hour`
+        /// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
         /// </summary>
         public readonly int StartMin;
 
         [OutputConstructor]
-        private AlertPolicyTimeRestrictionRestriction(
+        private ScheduleRotationTimeRestrictionRestrictionList(
+            string endDay,
+
             int endHour,
 
             int endMin,
+
+            string startDay,
 
             int startHour,
 
             int startMin)
         {
+            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
+            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestriction.cs
+++ b/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestriction.cs
@@ -14,19 +14,19 @@ namespace Pulumi.Opsgenie.Outputs
     public sealed class TeamRoutingRuleTimeRestriction
     {
         public readonly ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestriction> Restriction;
-        public readonly ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestriction> Restrictions;
+        public readonly ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestrictionList> RestrictionList;
         public readonly string Type;
 
         [OutputConstructor]
         private TeamRoutingRuleTimeRestriction(
             ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestriction> restriction,
 
-            ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestriction> restrictions,
+            ImmutableArray<Outputs.TeamRoutingRuleTimeRestrictionRestrictionList> restrictionList,
 
             string type)
         {
             Restriction = restriction;
-            Restrictions = restrictions;
+            RestrictionList = restrictionList;
             Type = type;
         }
     }

--- a/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestrictionRestriction.cs
+++ b/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestrictionRestriction.cs
@@ -13,31 +13,23 @@ namespace Pulumi.Opsgenie.Outputs
     [OutputType]
     public sealed class TeamRoutingRuleTimeRestrictionRestriction
     {
-        public readonly string EndDay;
         public readonly int EndHour;
         public readonly int EndMin;
-        public readonly string StartDay;
         public readonly int StartHour;
         public readonly int StartMin;
 
         [OutputConstructor]
         private TeamRoutingRuleTimeRestrictionRestriction(
-            string endDay,
-
             int endHour,
 
             int endMin,
-
-            string startDay,
 
             int startHour,
 
             int startMin)
         {
-            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
-            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestrictionRestrictionList.cs
+++ b/sdk/dotnet/Outputs/TeamRoutingRuleTimeRestrictionRestrictionList.cs
@@ -11,37 +11,33 @@ namespace Pulumi.Opsgenie.Outputs
 {
 
     [OutputType]
-    public sealed class AlertPolicyTimeRestrictionRestriction
+    public sealed class TeamRoutingRuleTimeRestrictionRestrictionList
     {
-        /// <summary>
-        /// Ending hour of restriction.
-        /// </summary>
+        public readonly string EndDay;
         public readonly int EndHour;
-        /// <summary>
-        /// Ending minute of restriction on defined `end_hour`
-        /// </summary>
         public readonly int EndMin;
-        /// <summary>
-        /// Starting hour of restriction.
-        /// </summary>
+        public readonly string StartDay;
         public readonly int StartHour;
-        /// <summary>
-        /// Staring minute of restriction on defined `start_hour`
-        /// </summary>
         public readonly int StartMin;
 
         [OutputConstructor]
-        private AlertPolicyTimeRestrictionRestriction(
+        private TeamRoutingRuleTimeRestrictionRestrictionList(
+            string endDay,
+
             int endHour,
 
             int endMin,
+
+            string startDay,
 
             int startHour,
 
             int startMin)
         {
+            EndDay = endDay;
             EndHour = endHour;
             EndMin = endMin;
+            StartDay = startDay;
             StartHour = startHour;
             StartMin = startMin;
         }

--- a/sdk/dotnet/TeamRoutingRule.cs
+++ b/sdk/dotnet/TeamRoutingRule.cs
@@ -65,9 +65,9 @@ namespace Pulumi.Opsgenie
     ///             {
     ///                 new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionArgs
     ///                 {
-    ///                     Restrictions = 
+    ///                     RestrictionList = 
     ///                     {
-    ///                         new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionRestrictionArgs
+    ///                         new Opsgenie.Inputs.TeamRoutingRuleTimeRestrictionRestrictionListArgs
     ///                         {
     ///                             EndDay = "tuesday",
     ///                             EndHour = 18,

--- a/sdk/dotnet/go.mod
+++ b/sdk/dotnet/go.mod
@@ -1,0 +1,3 @@
+module fake_dotnet_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/go/opsgenie/alertPolicy.go
+++ b/sdk/go/opsgenie/alertPolicy.go
@@ -41,8 +41,8 @@ import (
 // 			TimeRestrictions: AlertPolicyTimeRestrictionArray{
 // 				&AlertPolicyTimeRestrictionArgs{
 // 					Type: pulumi.String("weekday-and-time-of-day"),
-// 					Restrictions: AlertPolicyTimeRestrictionRestrictionArray{
-// 						&AlertPolicyTimeRestrictionRestrictionArgs{
+// 					RestrictionList: AlertPolicyTimeRestrictionRestrictionListArray{
+// 						&AlertPolicyTimeRestrictionRestrictionListArgs{
 // 							EndDay:    pulumi.String("monday"),
 // 							EndHour:   pulumi.Int(7),
 // 							EndMin:    pulumi.Int(0),
@@ -50,7 +50,7 @@ import (
 // 							StartHour: pulumi.Int(21),
 // 							StartMin:  pulumi.Int(0),
 // 						},
-// 						&AlertPolicyTimeRestrictionRestrictionArgs{
+// 						&AlertPolicyTimeRestrictionRestrictionListArgs{
 // 							EndDay:    pulumi.String("tuesday"),
 // 							EndHour:   pulumi.Int(7),
 // 							EndMin:    pulumi.Int(0),

--- a/sdk/go/opsgenie/pulumiTypes.go
+++ b/sdk/go/opsgenie/pulumiTypes.go
@@ -383,8 +383,10 @@ func (o AlertPolicyResponderArrayOutput) Index(i pulumi.IntInput) AlertPolicyRes
 }
 
 type AlertPolicyTimeRestriction struct {
+	// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+	Restriction []AlertPolicyTimeRestrictionRestriction `pulumi:"restriction"`
 	// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-	Restrictions []AlertPolicyTimeRestrictionRestriction `pulumi:"restrictions"`
+	RestrictionList []AlertPolicyTimeRestrictionRestrictionList `pulumi:"restrictionList"`
 	// Type of responder. Acceptable values are: `user` or `team`
 	Type string `pulumi:"type"`
 }
@@ -401,8 +403,10 @@ type AlertPolicyTimeRestrictionInput interface {
 }
 
 type AlertPolicyTimeRestrictionArgs struct {
+	// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+	Restriction AlertPolicyTimeRestrictionRestrictionArrayInput `pulumi:"restriction"`
 	// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-	Restrictions AlertPolicyTimeRestrictionRestrictionArrayInput `pulumi:"restrictions"`
+	RestrictionList AlertPolicyTimeRestrictionRestrictionListArrayInput `pulumi:"restrictionList"`
 	// Type of responder. Acceptable values are: `user` or `team`
 	Type pulumi.StringInput `pulumi:"type"`
 }
@@ -458,9 +462,16 @@ func (o AlertPolicyTimeRestrictionOutput) ToAlertPolicyTimeRestrictionOutputWith
 	return o
 }
 
+// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+func (o AlertPolicyTimeRestrictionOutput) Restriction() AlertPolicyTimeRestrictionRestrictionArrayOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestriction) []AlertPolicyTimeRestrictionRestriction { return v.Restriction }).(AlertPolicyTimeRestrictionRestrictionArrayOutput)
+}
+
 // List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-func (o AlertPolicyTimeRestrictionOutput) Restrictions() AlertPolicyTimeRestrictionRestrictionArrayOutput {
-	return o.ApplyT(func(v AlertPolicyTimeRestriction) []AlertPolicyTimeRestrictionRestriction { return v.Restrictions }).(AlertPolicyTimeRestrictionRestrictionArrayOutput)
+func (o AlertPolicyTimeRestrictionOutput) RestrictionList() AlertPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestriction) []AlertPolicyTimeRestrictionRestrictionList {
+		return v.RestrictionList
+	}).(AlertPolicyTimeRestrictionRestrictionListArrayOutput)
 }
 
 // Type of responder. Acceptable values are: `user` or `team`
@@ -489,14 +500,10 @@ func (o AlertPolicyTimeRestrictionArrayOutput) Index(i pulumi.IntInput) AlertPol
 }
 
 type AlertPolicyTimeRestrictionRestriction struct {
-	// Ending day of restriction (eg. `wednesday`)
-	EndDay string `pulumi:"endDay"`
 	// Ending hour of restriction.
 	EndHour int `pulumi:"endHour"`
 	// Ending minute of restriction on defined `endHour`
 	EndMin int `pulumi:"endMin"`
-	// Starting day of restriction (eg. `monday`)
-	StartDay string `pulumi:"startDay"`
 	// Starting hour of restriction.
 	StartHour int `pulumi:"startHour"`
 	// Staring minute of restriction on defined `startHour`
@@ -515,14 +522,10 @@ type AlertPolicyTimeRestrictionRestrictionInput interface {
 }
 
 type AlertPolicyTimeRestrictionRestrictionArgs struct {
-	// Ending day of restriction (eg. `wednesday`)
-	EndDay pulumi.StringInput `pulumi:"endDay"`
 	// Ending hour of restriction.
 	EndHour pulumi.IntInput `pulumi:"endHour"`
 	// Ending minute of restriction on defined `endHour`
 	EndMin pulumi.IntInput `pulumi:"endMin"`
-	// Starting day of restriction (eg. `monday`)
-	StartDay pulumi.StringInput `pulumi:"startDay"`
 	// Starting hour of restriction.
 	StartHour pulumi.IntInput `pulumi:"startHour"`
 	// Staring minute of restriction on defined `startHour`
@@ -580,11 +583,6 @@ func (o AlertPolicyTimeRestrictionRestrictionOutput) ToAlertPolicyTimeRestrictio
 	return o
 }
 
-// Ending day of restriction (eg. `wednesday`)
-func (o AlertPolicyTimeRestrictionRestrictionOutput) EndDay() pulumi.StringOutput {
-	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestriction) string { return v.EndDay }).(pulumi.StringOutput)
-}
-
 // Ending hour of restriction.
 func (o AlertPolicyTimeRestrictionRestrictionOutput) EndHour() pulumi.IntOutput {
 	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestriction) int { return v.EndHour }).(pulumi.IntOutput)
@@ -593,11 +591,6 @@ func (o AlertPolicyTimeRestrictionRestrictionOutput) EndHour() pulumi.IntOutput 
 // Ending minute of restriction on defined `endHour`
 func (o AlertPolicyTimeRestrictionRestrictionOutput) EndMin() pulumi.IntOutput {
 	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestriction) int { return v.EndMin }).(pulumi.IntOutput)
-}
-
-// Starting day of restriction (eg. `monday`)
-func (o AlertPolicyTimeRestrictionRestrictionOutput) StartDay() pulumi.StringOutput {
-	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestriction) string { return v.StartDay }).(pulumi.StringOutput)
 }
 
 // Starting hour of restriction.
@@ -628,6 +621,148 @@ func (o AlertPolicyTimeRestrictionRestrictionArrayOutput) Index(i pulumi.IntInpu
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) AlertPolicyTimeRestrictionRestriction {
 		return vs[0].([]AlertPolicyTimeRestrictionRestriction)[vs[1].(int)]
 	}).(AlertPolicyTimeRestrictionRestrictionOutput)
+}
+
+type AlertPolicyTimeRestrictionRestrictionList struct {
+	// Ending day of restriction (eg. `wednesday`)
+	EndDay string `pulumi:"endDay"`
+	// Ending hour of restriction.
+	EndHour int `pulumi:"endHour"`
+	// Ending minute of restriction on defined `endHour`
+	EndMin int `pulumi:"endMin"`
+	// Starting day of restriction (eg. `monday`)
+	StartDay string `pulumi:"startDay"`
+	// Starting hour of restriction.
+	StartHour int `pulumi:"startHour"`
+	// Staring minute of restriction on defined `startHour`
+	StartMin int `pulumi:"startMin"`
+}
+
+// AlertPolicyTimeRestrictionRestrictionListInput is an input type that accepts AlertPolicyTimeRestrictionRestrictionListArgs and AlertPolicyTimeRestrictionRestrictionListOutput values.
+// You can construct a concrete instance of `AlertPolicyTimeRestrictionRestrictionListInput` via:
+//
+//          AlertPolicyTimeRestrictionRestrictionListArgs{...}
+type AlertPolicyTimeRestrictionRestrictionListInput interface {
+	pulumi.Input
+
+	ToAlertPolicyTimeRestrictionRestrictionListOutput() AlertPolicyTimeRestrictionRestrictionListOutput
+	ToAlertPolicyTimeRestrictionRestrictionListOutputWithContext(context.Context) AlertPolicyTimeRestrictionRestrictionListOutput
+}
+
+type AlertPolicyTimeRestrictionRestrictionListArgs struct {
+	// Ending day of restriction (eg. `wednesday`)
+	EndDay pulumi.StringInput `pulumi:"endDay"`
+	// Ending hour of restriction.
+	EndHour pulumi.IntInput `pulumi:"endHour"`
+	// Ending minute of restriction on defined `endHour`
+	EndMin pulumi.IntInput `pulumi:"endMin"`
+	// Starting day of restriction (eg. `monday`)
+	StartDay pulumi.StringInput `pulumi:"startDay"`
+	// Starting hour of restriction.
+	StartHour pulumi.IntInput `pulumi:"startHour"`
+	// Staring minute of restriction on defined `startHour`
+	StartMin pulumi.IntInput `pulumi:"startMin"`
+}
+
+func (AlertPolicyTimeRestrictionRestrictionListArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i AlertPolicyTimeRestrictionRestrictionListArgs) ToAlertPolicyTimeRestrictionRestrictionListOutput() AlertPolicyTimeRestrictionRestrictionListOutput {
+	return i.ToAlertPolicyTimeRestrictionRestrictionListOutputWithContext(context.Background())
+}
+
+func (i AlertPolicyTimeRestrictionRestrictionListArgs) ToAlertPolicyTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) AlertPolicyTimeRestrictionRestrictionListOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(AlertPolicyTimeRestrictionRestrictionListOutput)
+}
+
+// AlertPolicyTimeRestrictionRestrictionListArrayInput is an input type that accepts AlertPolicyTimeRestrictionRestrictionListArray and AlertPolicyTimeRestrictionRestrictionListArrayOutput values.
+// You can construct a concrete instance of `AlertPolicyTimeRestrictionRestrictionListArrayInput` via:
+//
+//          AlertPolicyTimeRestrictionRestrictionListArray{ AlertPolicyTimeRestrictionRestrictionListArgs{...} }
+type AlertPolicyTimeRestrictionRestrictionListArrayInput interface {
+	pulumi.Input
+
+	ToAlertPolicyTimeRestrictionRestrictionListArrayOutput() AlertPolicyTimeRestrictionRestrictionListArrayOutput
+	ToAlertPolicyTimeRestrictionRestrictionListArrayOutputWithContext(context.Context) AlertPolicyTimeRestrictionRestrictionListArrayOutput
+}
+
+type AlertPolicyTimeRestrictionRestrictionListArray []AlertPolicyTimeRestrictionRestrictionListInput
+
+func (AlertPolicyTimeRestrictionRestrictionListArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]AlertPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i AlertPolicyTimeRestrictionRestrictionListArray) ToAlertPolicyTimeRestrictionRestrictionListArrayOutput() AlertPolicyTimeRestrictionRestrictionListArrayOutput {
+	return i.ToAlertPolicyTimeRestrictionRestrictionListArrayOutputWithContext(context.Background())
+}
+
+func (i AlertPolicyTimeRestrictionRestrictionListArray) ToAlertPolicyTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) AlertPolicyTimeRestrictionRestrictionListArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(AlertPolicyTimeRestrictionRestrictionListArrayOutput)
+}
+
+type AlertPolicyTimeRestrictionRestrictionListOutput struct{ *pulumi.OutputState }
+
+func (AlertPolicyTimeRestrictionRestrictionListOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) ToAlertPolicyTimeRestrictionRestrictionListOutput() AlertPolicyTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) ToAlertPolicyTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) AlertPolicyTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+// Ending day of restriction (eg. `wednesday`)
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) EndDay() pulumi.StringOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) string { return v.EndDay }).(pulumi.StringOutput)
+}
+
+// Ending hour of restriction.
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) EndHour() pulumi.IntOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) int { return v.EndHour }).(pulumi.IntOutput)
+}
+
+// Ending minute of restriction on defined `endHour`
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) EndMin() pulumi.IntOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) int { return v.EndMin }).(pulumi.IntOutput)
+}
+
+// Starting day of restriction (eg. `monday`)
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) StartDay() pulumi.StringOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) string { return v.StartDay }).(pulumi.StringOutput)
+}
+
+// Starting hour of restriction.
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) StartHour() pulumi.IntOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) int { return v.StartHour }).(pulumi.IntOutput)
+}
+
+// Staring minute of restriction on defined `startHour`
+func (o AlertPolicyTimeRestrictionRestrictionListOutput) StartMin() pulumi.IntOutput {
+	return o.ApplyT(func(v AlertPolicyTimeRestrictionRestrictionList) int { return v.StartMin }).(pulumi.IntOutput)
+}
+
+type AlertPolicyTimeRestrictionRestrictionListArrayOutput struct{ *pulumi.OutputState }
+
+func (AlertPolicyTimeRestrictionRestrictionListArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]AlertPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o AlertPolicyTimeRestrictionRestrictionListArrayOutput) ToAlertPolicyTimeRestrictionRestrictionListArrayOutput() AlertPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o AlertPolicyTimeRestrictionRestrictionListArrayOutput) ToAlertPolicyTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) AlertPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o AlertPolicyTimeRestrictionRestrictionListArrayOutput) Index(i pulumi.IntInput) AlertPolicyTimeRestrictionRestrictionListOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) AlertPolicyTimeRestrictionRestrictionList {
+		return vs[0].([]AlertPolicyTimeRestrictionRestrictionList)[vs[1].(int)]
+	}).(AlertPolicyTimeRestrictionRestrictionListOutput)
 }
 
 type ApiIntegrationResponder struct {
@@ -4907,7 +5042,7 @@ type NotificationPolicyTimeRestriction struct {
 	// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
 	Restriction []NotificationPolicyTimeRestrictionRestriction `pulumi:"restriction"`
 	// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-	Restrictions []NotificationPolicyTimeRestrictionRestriction `pulumi:"restrictions"`
+	RestrictionList []NotificationPolicyTimeRestrictionRestrictionList `pulumi:"restrictionList"`
 	// Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
 	Type string `pulumi:"type"`
 }
@@ -4927,7 +5062,7 @@ type NotificationPolicyTimeRestrictionArgs struct {
 	// A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
 	Restriction NotificationPolicyTimeRestrictionRestrictionArrayInput `pulumi:"restriction"`
 	// List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-	Restrictions NotificationPolicyTimeRestrictionRestrictionArrayInput `pulumi:"restrictions"`
+	RestrictionList NotificationPolicyTimeRestrictionRestrictionListArrayInput `pulumi:"restrictionList"`
 	// Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
 	Type pulumi.StringInput `pulumi:"type"`
 }
@@ -4991,10 +5126,10 @@ func (o NotificationPolicyTimeRestrictionOutput) Restriction() NotificationPolic
 }
 
 // List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
-func (o NotificationPolicyTimeRestrictionOutput) Restrictions() NotificationPolicyTimeRestrictionRestrictionArrayOutput {
-	return o.ApplyT(func(v NotificationPolicyTimeRestriction) []NotificationPolicyTimeRestrictionRestriction {
-		return v.Restrictions
-	}).(NotificationPolicyTimeRestrictionRestrictionArrayOutput)
+func (o NotificationPolicyTimeRestrictionOutput) RestrictionList() NotificationPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestriction) []NotificationPolicyTimeRestrictionRestrictionList {
+		return v.RestrictionList
+	}).(NotificationPolicyTimeRestrictionRestrictionListArrayOutput)
 }
 
 // Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
@@ -5023,14 +5158,10 @@ func (o NotificationPolicyTimeRestrictionArrayOutput) Index(i pulumi.IntInput) N
 }
 
 type NotificationPolicyTimeRestrictionRestriction struct {
-	// Ending day of restriction (eg. `wednesday`)
-	EndDay string `pulumi:"endDay"`
 	// Ending hour of restriction.
 	EndHour int `pulumi:"endHour"`
 	// Ending minute of restriction on defined `endHour`
 	EndMin int `pulumi:"endMin"`
-	// Starting day of restriction (eg. `monday`)
-	StartDay string `pulumi:"startDay"`
 	// Starting hour of restriction.
 	StartHour int `pulumi:"startHour"`
 	// Staring minute of restriction on defined `startHour`
@@ -5049,14 +5180,10 @@ type NotificationPolicyTimeRestrictionRestrictionInput interface {
 }
 
 type NotificationPolicyTimeRestrictionRestrictionArgs struct {
-	// Ending day of restriction (eg. `wednesday`)
-	EndDay pulumi.StringInput `pulumi:"endDay"`
 	// Ending hour of restriction.
 	EndHour pulumi.IntInput `pulumi:"endHour"`
 	// Ending minute of restriction on defined `endHour`
 	EndMin pulumi.IntInput `pulumi:"endMin"`
-	// Starting day of restriction (eg. `monday`)
-	StartDay pulumi.StringInput `pulumi:"startDay"`
 	// Starting hour of restriction.
 	StartHour pulumi.IntInput `pulumi:"startHour"`
 	// Staring minute of restriction on defined `startHour`
@@ -5114,11 +5241,6 @@ func (o NotificationPolicyTimeRestrictionRestrictionOutput) ToNotificationPolicy
 	return o
 }
 
-// Ending day of restriction (eg. `wednesday`)
-func (o NotificationPolicyTimeRestrictionRestrictionOutput) EndDay() pulumi.StringOutput {
-	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestriction) string { return v.EndDay }).(pulumi.StringOutput)
-}
-
 // Ending hour of restriction.
 func (o NotificationPolicyTimeRestrictionRestrictionOutput) EndHour() pulumi.IntOutput {
 	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestriction) int { return v.EndHour }).(pulumi.IntOutput)
@@ -5127,11 +5249,6 @@ func (o NotificationPolicyTimeRestrictionRestrictionOutput) EndHour() pulumi.Int
 // Ending minute of restriction on defined `endHour`
 func (o NotificationPolicyTimeRestrictionRestrictionOutput) EndMin() pulumi.IntOutput {
 	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestriction) int { return v.EndMin }).(pulumi.IntOutput)
-}
-
-// Starting day of restriction (eg. `monday`)
-func (o NotificationPolicyTimeRestrictionRestrictionOutput) StartDay() pulumi.StringOutput {
-	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestriction) string { return v.StartDay }).(pulumi.StringOutput)
 }
 
 // Starting hour of restriction.
@@ -5162,6 +5279,148 @@ func (o NotificationPolicyTimeRestrictionRestrictionArrayOutput) Index(i pulumi.
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) NotificationPolicyTimeRestrictionRestriction {
 		return vs[0].([]NotificationPolicyTimeRestrictionRestriction)[vs[1].(int)]
 	}).(NotificationPolicyTimeRestrictionRestrictionOutput)
+}
+
+type NotificationPolicyTimeRestrictionRestrictionList struct {
+	// Ending day of restriction (eg. `wednesday`)
+	EndDay string `pulumi:"endDay"`
+	// Ending hour of restriction.
+	EndHour int `pulumi:"endHour"`
+	// Ending minute of restriction on defined `endHour`
+	EndMin int `pulumi:"endMin"`
+	// Starting day of restriction (eg. `monday`)
+	StartDay string `pulumi:"startDay"`
+	// Starting hour of restriction.
+	StartHour int `pulumi:"startHour"`
+	// Staring minute of restriction on defined `startHour`
+	StartMin int `pulumi:"startMin"`
+}
+
+// NotificationPolicyTimeRestrictionRestrictionListInput is an input type that accepts NotificationPolicyTimeRestrictionRestrictionListArgs and NotificationPolicyTimeRestrictionRestrictionListOutput values.
+// You can construct a concrete instance of `NotificationPolicyTimeRestrictionRestrictionListInput` via:
+//
+//          NotificationPolicyTimeRestrictionRestrictionListArgs{...}
+type NotificationPolicyTimeRestrictionRestrictionListInput interface {
+	pulumi.Input
+
+	ToNotificationPolicyTimeRestrictionRestrictionListOutput() NotificationPolicyTimeRestrictionRestrictionListOutput
+	ToNotificationPolicyTimeRestrictionRestrictionListOutputWithContext(context.Context) NotificationPolicyTimeRestrictionRestrictionListOutput
+}
+
+type NotificationPolicyTimeRestrictionRestrictionListArgs struct {
+	// Ending day of restriction (eg. `wednesday`)
+	EndDay pulumi.StringInput `pulumi:"endDay"`
+	// Ending hour of restriction.
+	EndHour pulumi.IntInput `pulumi:"endHour"`
+	// Ending minute of restriction on defined `endHour`
+	EndMin pulumi.IntInput `pulumi:"endMin"`
+	// Starting day of restriction (eg. `monday`)
+	StartDay pulumi.StringInput `pulumi:"startDay"`
+	// Starting hour of restriction.
+	StartHour pulumi.IntInput `pulumi:"startHour"`
+	// Staring minute of restriction on defined `startHour`
+	StartMin pulumi.IntInput `pulumi:"startMin"`
+}
+
+func (NotificationPolicyTimeRestrictionRestrictionListArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i NotificationPolicyTimeRestrictionRestrictionListArgs) ToNotificationPolicyTimeRestrictionRestrictionListOutput() NotificationPolicyTimeRestrictionRestrictionListOutput {
+	return i.ToNotificationPolicyTimeRestrictionRestrictionListOutputWithContext(context.Background())
+}
+
+func (i NotificationPolicyTimeRestrictionRestrictionListArgs) ToNotificationPolicyTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) NotificationPolicyTimeRestrictionRestrictionListOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(NotificationPolicyTimeRestrictionRestrictionListOutput)
+}
+
+// NotificationPolicyTimeRestrictionRestrictionListArrayInput is an input type that accepts NotificationPolicyTimeRestrictionRestrictionListArray and NotificationPolicyTimeRestrictionRestrictionListArrayOutput values.
+// You can construct a concrete instance of `NotificationPolicyTimeRestrictionRestrictionListArrayInput` via:
+//
+//          NotificationPolicyTimeRestrictionRestrictionListArray{ NotificationPolicyTimeRestrictionRestrictionListArgs{...} }
+type NotificationPolicyTimeRestrictionRestrictionListArrayInput interface {
+	pulumi.Input
+
+	ToNotificationPolicyTimeRestrictionRestrictionListArrayOutput() NotificationPolicyTimeRestrictionRestrictionListArrayOutput
+	ToNotificationPolicyTimeRestrictionRestrictionListArrayOutputWithContext(context.Context) NotificationPolicyTimeRestrictionRestrictionListArrayOutput
+}
+
+type NotificationPolicyTimeRestrictionRestrictionListArray []NotificationPolicyTimeRestrictionRestrictionListInput
+
+func (NotificationPolicyTimeRestrictionRestrictionListArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]NotificationPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i NotificationPolicyTimeRestrictionRestrictionListArray) ToNotificationPolicyTimeRestrictionRestrictionListArrayOutput() NotificationPolicyTimeRestrictionRestrictionListArrayOutput {
+	return i.ToNotificationPolicyTimeRestrictionRestrictionListArrayOutputWithContext(context.Background())
+}
+
+func (i NotificationPolicyTimeRestrictionRestrictionListArray) ToNotificationPolicyTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) NotificationPolicyTimeRestrictionRestrictionListArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(NotificationPolicyTimeRestrictionRestrictionListArrayOutput)
+}
+
+type NotificationPolicyTimeRestrictionRestrictionListOutput struct{ *pulumi.OutputState }
+
+func (NotificationPolicyTimeRestrictionRestrictionListOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) ToNotificationPolicyTimeRestrictionRestrictionListOutput() NotificationPolicyTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) ToNotificationPolicyTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) NotificationPolicyTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+// Ending day of restriction (eg. `wednesday`)
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) EndDay() pulumi.StringOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) string { return v.EndDay }).(pulumi.StringOutput)
+}
+
+// Ending hour of restriction.
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) EndHour() pulumi.IntOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) int { return v.EndHour }).(pulumi.IntOutput)
+}
+
+// Ending minute of restriction on defined `endHour`
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) EndMin() pulumi.IntOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) int { return v.EndMin }).(pulumi.IntOutput)
+}
+
+// Starting day of restriction (eg. `monday`)
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) StartDay() pulumi.StringOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) string { return v.StartDay }).(pulumi.StringOutput)
+}
+
+// Starting hour of restriction.
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) StartHour() pulumi.IntOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) int { return v.StartHour }).(pulumi.IntOutput)
+}
+
+// Staring minute of restriction on defined `startHour`
+func (o NotificationPolicyTimeRestrictionRestrictionListOutput) StartMin() pulumi.IntOutput {
+	return o.ApplyT(func(v NotificationPolicyTimeRestrictionRestrictionList) int { return v.StartMin }).(pulumi.IntOutput)
+}
+
+type NotificationPolicyTimeRestrictionRestrictionListArrayOutput struct{ *pulumi.OutputState }
+
+func (NotificationPolicyTimeRestrictionRestrictionListArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]NotificationPolicyTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o NotificationPolicyTimeRestrictionRestrictionListArrayOutput) ToNotificationPolicyTimeRestrictionRestrictionListArrayOutput() NotificationPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o NotificationPolicyTimeRestrictionRestrictionListArrayOutput) ToNotificationPolicyTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) NotificationPolicyTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o NotificationPolicyTimeRestrictionRestrictionListArrayOutput) Index(i pulumi.IntInput) NotificationPolicyTimeRestrictionRestrictionListOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) NotificationPolicyTimeRestrictionRestrictionList {
+		return vs[0].([]NotificationPolicyTimeRestrictionRestrictionList)[vs[1].(int)]
+	}).(NotificationPolicyTimeRestrictionRestrictionListOutput)
 }
 
 type NotificationRuleCriteria struct {
@@ -6181,7 +6440,7 @@ type ScheduleRotationTimeRestriction struct {
 	// It is a restriction object which is described below. In this case startDay/endDay fields are not supported. This can be used only if time restriction type is `time-of-day`.
 	Restriction []ScheduleRotationTimeRestrictionRestriction `pulumi:"restriction"`
 	// It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
-	Restrictions []ScheduleRotationTimeRestrictionRestriction `pulumi:"restrictions"`
+	RestrictionList []ScheduleRotationTimeRestrictionRestrictionList `pulumi:"restrictionList"`
 	// This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
 	Type string `pulumi:"type"`
 }
@@ -6201,7 +6460,7 @@ type ScheduleRotationTimeRestrictionArgs struct {
 	// It is a restriction object which is described below. In this case startDay/endDay fields are not supported. This can be used only if time restriction type is `time-of-day`.
 	Restriction ScheduleRotationTimeRestrictionRestrictionArrayInput `pulumi:"restriction"`
 	// It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
-	Restrictions ScheduleRotationTimeRestrictionRestrictionArrayInput `pulumi:"restrictions"`
+	RestrictionList ScheduleRotationTimeRestrictionRestrictionListArrayInput `pulumi:"restrictionList"`
 	// This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
 	Type pulumi.StringInput `pulumi:"type"`
 }
@@ -6265,10 +6524,10 @@ func (o ScheduleRotationTimeRestrictionOutput) Restriction() ScheduleRotationTim
 }
 
 // It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
-func (o ScheduleRotationTimeRestrictionOutput) Restrictions() ScheduleRotationTimeRestrictionRestrictionArrayOutput {
-	return o.ApplyT(func(v ScheduleRotationTimeRestriction) []ScheduleRotationTimeRestrictionRestriction {
-		return v.Restrictions
-	}).(ScheduleRotationTimeRestrictionRestrictionArrayOutput)
+func (o ScheduleRotationTimeRestrictionOutput) RestrictionList() ScheduleRotationTimeRestrictionRestrictionListArrayOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestriction) []ScheduleRotationTimeRestrictionRestrictionList {
+		return v.RestrictionList
+	}).(ScheduleRotationTimeRestrictionRestrictionListArrayOutput)
 }
 
 // This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
@@ -6297,15 +6556,11 @@ func (o ScheduleRotationTimeRestrictionArrayOutput) Index(i pulumi.IntInput) Sch
 }
 
 type ScheduleRotationTimeRestrictionRestriction struct {
-	// Value of the day that frame will end.
-	EndDay string `pulumi:"endDay"`
 	// Value of the hour that frame will end.
 	EndHour int `pulumi:"endHour"`
 	// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
 	EndMin int `pulumi:"endMin"`
-	// Value of the day that frame will start.
-	StartDay string `pulumi:"startDay"`
-	// Value of the hour that frame will start
+	// Value of the hour that frame will start.
 	StartHour int `pulumi:"startHour"`
 	// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
 	StartMin int `pulumi:"startMin"`
@@ -6323,15 +6578,11 @@ type ScheduleRotationTimeRestrictionRestrictionInput interface {
 }
 
 type ScheduleRotationTimeRestrictionRestrictionArgs struct {
-	// Value of the day that frame will end.
-	EndDay pulumi.StringInput `pulumi:"endDay"`
 	// Value of the hour that frame will end.
 	EndHour pulumi.IntInput `pulumi:"endHour"`
 	// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
 	EndMin pulumi.IntInput `pulumi:"endMin"`
-	// Value of the day that frame will start.
-	StartDay pulumi.StringInput `pulumi:"startDay"`
-	// Value of the hour that frame will start
+	// Value of the hour that frame will start.
 	StartHour pulumi.IntInput `pulumi:"startHour"`
 	// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
 	StartMin pulumi.IntInput `pulumi:"startMin"`
@@ -6388,11 +6639,6 @@ func (o ScheduleRotationTimeRestrictionRestrictionOutput) ToScheduleRotationTime
 	return o
 }
 
-// Value of the day that frame will end.
-func (o ScheduleRotationTimeRestrictionRestrictionOutput) EndDay() pulumi.StringOutput {
-	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestriction) string { return v.EndDay }).(pulumi.StringOutput)
-}
-
 // Value of the hour that frame will end.
 func (o ScheduleRotationTimeRestrictionRestrictionOutput) EndHour() pulumi.IntOutput {
 	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestriction) int { return v.EndHour }).(pulumi.IntOutput)
@@ -6403,12 +6649,7 @@ func (o ScheduleRotationTimeRestrictionRestrictionOutput) EndMin() pulumi.IntOut
 	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestriction) int { return v.EndMin }).(pulumi.IntOutput)
 }
 
-// Value of the day that frame will start.
-func (o ScheduleRotationTimeRestrictionRestrictionOutput) StartDay() pulumi.StringOutput {
-	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestriction) string { return v.StartDay }).(pulumi.StringOutput)
-}
-
-// Value of the hour that frame will start
+// Value of the hour that frame will start.
 func (o ScheduleRotationTimeRestrictionRestrictionOutput) StartHour() pulumi.IntOutput {
 	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestriction) int { return v.StartHour }).(pulumi.IntOutput)
 }
@@ -6436,6 +6677,148 @@ func (o ScheduleRotationTimeRestrictionRestrictionArrayOutput) Index(i pulumi.In
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ScheduleRotationTimeRestrictionRestriction {
 		return vs[0].([]ScheduleRotationTimeRestrictionRestriction)[vs[1].(int)]
 	}).(ScheduleRotationTimeRestrictionRestrictionOutput)
+}
+
+type ScheduleRotationTimeRestrictionRestrictionList struct {
+	// Value of the day that frame will end.
+	EndDay string `pulumi:"endDay"`
+	// Value of the hour that frame will end.
+	EndHour int `pulumi:"endHour"`
+	// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+	EndMin int `pulumi:"endMin"`
+	// Value of the day that frame will start.
+	StartDay string `pulumi:"startDay"`
+	// Value of the hour that frame will start
+	StartHour int `pulumi:"startHour"`
+	// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+	StartMin int `pulumi:"startMin"`
+}
+
+// ScheduleRotationTimeRestrictionRestrictionListInput is an input type that accepts ScheduleRotationTimeRestrictionRestrictionListArgs and ScheduleRotationTimeRestrictionRestrictionListOutput values.
+// You can construct a concrete instance of `ScheduleRotationTimeRestrictionRestrictionListInput` via:
+//
+//          ScheduleRotationTimeRestrictionRestrictionListArgs{...}
+type ScheduleRotationTimeRestrictionRestrictionListInput interface {
+	pulumi.Input
+
+	ToScheduleRotationTimeRestrictionRestrictionListOutput() ScheduleRotationTimeRestrictionRestrictionListOutput
+	ToScheduleRotationTimeRestrictionRestrictionListOutputWithContext(context.Context) ScheduleRotationTimeRestrictionRestrictionListOutput
+}
+
+type ScheduleRotationTimeRestrictionRestrictionListArgs struct {
+	// Value of the day that frame will end.
+	EndDay pulumi.StringInput `pulumi:"endDay"`
+	// Value of the hour that frame will end.
+	EndHour pulumi.IntInput `pulumi:"endHour"`
+	// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+	EndMin pulumi.IntInput `pulumi:"endMin"`
+	// Value of the day that frame will start.
+	StartDay pulumi.StringInput `pulumi:"startDay"`
+	// Value of the hour that frame will start
+	StartHour pulumi.IntInput `pulumi:"startHour"`
+	// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+	StartMin pulumi.IntInput `pulumi:"startMin"`
+}
+
+func (ScheduleRotationTimeRestrictionRestrictionListArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i ScheduleRotationTimeRestrictionRestrictionListArgs) ToScheduleRotationTimeRestrictionRestrictionListOutput() ScheduleRotationTimeRestrictionRestrictionListOutput {
+	return i.ToScheduleRotationTimeRestrictionRestrictionListOutputWithContext(context.Background())
+}
+
+func (i ScheduleRotationTimeRestrictionRestrictionListArgs) ToScheduleRotationTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) ScheduleRotationTimeRestrictionRestrictionListOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScheduleRotationTimeRestrictionRestrictionListOutput)
+}
+
+// ScheduleRotationTimeRestrictionRestrictionListArrayInput is an input type that accepts ScheduleRotationTimeRestrictionRestrictionListArray and ScheduleRotationTimeRestrictionRestrictionListArrayOutput values.
+// You can construct a concrete instance of `ScheduleRotationTimeRestrictionRestrictionListArrayInput` via:
+//
+//          ScheduleRotationTimeRestrictionRestrictionListArray{ ScheduleRotationTimeRestrictionRestrictionListArgs{...} }
+type ScheduleRotationTimeRestrictionRestrictionListArrayInput interface {
+	pulumi.Input
+
+	ToScheduleRotationTimeRestrictionRestrictionListArrayOutput() ScheduleRotationTimeRestrictionRestrictionListArrayOutput
+	ToScheduleRotationTimeRestrictionRestrictionListArrayOutputWithContext(context.Context) ScheduleRotationTimeRestrictionRestrictionListArrayOutput
+}
+
+type ScheduleRotationTimeRestrictionRestrictionListArray []ScheduleRotationTimeRestrictionRestrictionListInput
+
+func (ScheduleRotationTimeRestrictionRestrictionListArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ScheduleRotationTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i ScheduleRotationTimeRestrictionRestrictionListArray) ToScheduleRotationTimeRestrictionRestrictionListArrayOutput() ScheduleRotationTimeRestrictionRestrictionListArrayOutput {
+	return i.ToScheduleRotationTimeRestrictionRestrictionListArrayOutputWithContext(context.Background())
+}
+
+func (i ScheduleRotationTimeRestrictionRestrictionListArray) ToScheduleRotationTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) ScheduleRotationTimeRestrictionRestrictionListArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScheduleRotationTimeRestrictionRestrictionListArrayOutput)
+}
+
+type ScheduleRotationTimeRestrictionRestrictionListOutput struct{ *pulumi.OutputState }
+
+func (ScheduleRotationTimeRestrictionRestrictionListOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) ToScheduleRotationTimeRestrictionRestrictionListOutput() ScheduleRotationTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) ToScheduleRotationTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) ScheduleRotationTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+// Value of the day that frame will end.
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) EndDay() pulumi.StringOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) string { return v.EndDay }).(pulumi.StringOutput)
+}
+
+// Value of the hour that frame will end.
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) EndHour() pulumi.IntOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) int { return v.EndHour }).(pulumi.IntOutput)
+}
+
+// Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) EndMin() pulumi.IntOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) int { return v.EndMin }).(pulumi.IntOutput)
+}
+
+// Value of the day that frame will start.
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) StartDay() pulumi.StringOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) string { return v.StartDay }).(pulumi.StringOutput)
+}
+
+// Value of the hour that frame will start
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) StartHour() pulumi.IntOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) int { return v.StartHour }).(pulumi.IntOutput)
+}
+
+// Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+func (o ScheduleRotationTimeRestrictionRestrictionListOutput) StartMin() pulumi.IntOutput {
+	return o.ApplyT(func(v ScheduleRotationTimeRestrictionRestrictionList) int { return v.StartMin }).(pulumi.IntOutput)
+}
+
+type ScheduleRotationTimeRestrictionRestrictionListArrayOutput struct{ *pulumi.OutputState }
+
+func (ScheduleRotationTimeRestrictionRestrictionListArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ScheduleRotationTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o ScheduleRotationTimeRestrictionRestrictionListArrayOutput) ToScheduleRotationTimeRestrictionRestrictionListArrayOutput() ScheduleRotationTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o ScheduleRotationTimeRestrictionRestrictionListArrayOutput) ToScheduleRotationTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) ScheduleRotationTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o ScheduleRotationTimeRestrictionRestrictionListArrayOutput) Index(i pulumi.IntInput) ScheduleRotationTimeRestrictionRestrictionListOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ScheduleRotationTimeRestrictionRestrictionList {
+		return vs[0].([]ScheduleRotationTimeRestrictionRestrictionList)[vs[1].(int)]
+	}).(ScheduleRotationTimeRestrictionRestrictionListOutput)
 }
 
 type ServiceIncidentRuleIncidentRule struct {
@@ -7412,9 +7795,9 @@ func (o TeamRoutingRuleNotifyArrayOutput) Index(i pulumi.IntInput) TeamRoutingRu
 }
 
 type TeamRoutingRuleTimeRestriction struct {
-	Restriction  []TeamRoutingRuleTimeRestrictionRestriction `pulumi:"restriction"`
-	Restrictions []TeamRoutingRuleTimeRestrictionRestriction `pulumi:"restrictions"`
-	Type         string                                      `pulumi:"type"`
+	Restriction     []TeamRoutingRuleTimeRestrictionRestriction     `pulumi:"restriction"`
+	RestrictionList []TeamRoutingRuleTimeRestrictionRestrictionList `pulumi:"restrictionList"`
+	Type            string                                          `pulumi:"type"`
 }
 
 // TeamRoutingRuleTimeRestrictionInput is an input type that accepts TeamRoutingRuleTimeRestrictionArgs and TeamRoutingRuleTimeRestrictionOutput values.
@@ -7429,9 +7812,9 @@ type TeamRoutingRuleTimeRestrictionInput interface {
 }
 
 type TeamRoutingRuleTimeRestrictionArgs struct {
-	Restriction  TeamRoutingRuleTimeRestrictionRestrictionArrayInput `pulumi:"restriction"`
-	Restrictions TeamRoutingRuleTimeRestrictionRestrictionArrayInput `pulumi:"restrictions"`
-	Type         pulumi.StringInput                                  `pulumi:"type"`
+	Restriction     TeamRoutingRuleTimeRestrictionRestrictionArrayInput     `pulumi:"restriction"`
+	RestrictionList TeamRoutingRuleTimeRestrictionRestrictionListArrayInput `pulumi:"restrictionList"`
+	Type            pulumi.StringInput                                      `pulumi:"type"`
 }
 
 func (TeamRoutingRuleTimeRestrictionArgs) ElementType() reflect.Type {
@@ -7491,10 +7874,10 @@ func (o TeamRoutingRuleTimeRestrictionOutput) Restriction() TeamRoutingRuleTimeR
 	}).(TeamRoutingRuleTimeRestrictionRestrictionArrayOutput)
 }
 
-func (o TeamRoutingRuleTimeRestrictionOutput) Restrictions() TeamRoutingRuleTimeRestrictionRestrictionArrayOutput {
-	return o.ApplyT(func(v TeamRoutingRuleTimeRestriction) []TeamRoutingRuleTimeRestrictionRestriction {
-		return v.Restrictions
-	}).(TeamRoutingRuleTimeRestrictionRestrictionArrayOutput)
+func (o TeamRoutingRuleTimeRestrictionOutput) RestrictionList() TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestriction) []TeamRoutingRuleTimeRestrictionRestrictionList {
+		return v.RestrictionList
+	}).(TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput)
 }
 
 func (o TeamRoutingRuleTimeRestrictionOutput) Type() pulumi.StringOutput {
@@ -7522,12 +7905,10 @@ func (o TeamRoutingRuleTimeRestrictionArrayOutput) Index(i pulumi.IntInput) Team
 }
 
 type TeamRoutingRuleTimeRestrictionRestriction struct {
-	EndDay    string `pulumi:"endDay"`
-	EndHour   int    `pulumi:"endHour"`
-	EndMin    int    `pulumi:"endMin"`
-	StartDay  string `pulumi:"startDay"`
-	StartHour int    `pulumi:"startHour"`
-	StartMin  int    `pulumi:"startMin"`
+	EndHour   int `pulumi:"endHour"`
+	EndMin    int `pulumi:"endMin"`
+	StartHour int `pulumi:"startHour"`
+	StartMin  int `pulumi:"startMin"`
 }
 
 // TeamRoutingRuleTimeRestrictionRestrictionInput is an input type that accepts TeamRoutingRuleTimeRestrictionRestrictionArgs and TeamRoutingRuleTimeRestrictionRestrictionOutput values.
@@ -7542,12 +7923,10 @@ type TeamRoutingRuleTimeRestrictionRestrictionInput interface {
 }
 
 type TeamRoutingRuleTimeRestrictionRestrictionArgs struct {
-	EndDay    pulumi.StringInput `pulumi:"endDay"`
-	EndHour   pulumi.IntInput    `pulumi:"endHour"`
-	EndMin    pulumi.IntInput    `pulumi:"endMin"`
-	StartDay  pulumi.StringInput `pulumi:"startDay"`
-	StartHour pulumi.IntInput    `pulumi:"startHour"`
-	StartMin  pulumi.IntInput    `pulumi:"startMin"`
+	EndHour   pulumi.IntInput `pulumi:"endHour"`
+	EndMin    pulumi.IntInput `pulumi:"endMin"`
+	StartHour pulumi.IntInput `pulumi:"startHour"`
+	StartMin  pulumi.IntInput `pulumi:"startMin"`
 }
 
 func (TeamRoutingRuleTimeRestrictionRestrictionArgs) ElementType() reflect.Type {
@@ -7601,20 +7980,12 @@ func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) ToTeamRoutingRuleTimeRe
 	return o
 }
 
-func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) EndDay() pulumi.StringOutput {
-	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestriction) string { return v.EndDay }).(pulumi.StringOutput)
-}
-
 func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) EndHour() pulumi.IntOutput {
 	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestriction) int { return v.EndHour }).(pulumi.IntOutput)
 }
 
 func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) EndMin() pulumi.IntOutput {
 	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestriction) int { return v.EndMin }).(pulumi.IntOutput)
-}
-
-func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) StartDay() pulumi.StringOutput {
-	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestriction) string { return v.StartDay }).(pulumi.StringOutput)
 }
 
 func (o TeamRoutingRuleTimeRestrictionRestrictionOutput) StartHour() pulumi.IntOutput {
@@ -7643,6 +8014,130 @@ func (o TeamRoutingRuleTimeRestrictionRestrictionArrayOutput) Index(i pulumi.Int
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TeamRoutingRuleTimeRestrictionRestriction {
 		return vs[0].([]TeamRoutingRuleTimeRestrictionRestriction)[vs[1].(int)]
 	}).(TeamRoutingRuleTimeRestrictionRestrictionOutput)
+}
+
+type TeamRoutingRuleTimeRestrictionRestrictionList struct {
+	EndDay    string `pulumi:"endDay"`
+	EndHour   int    `pulumi:"endHour"`
+	EndMin    int    `pulumi:"endMin"`
+	StartDay  string `pulumi:"startDay"`
+	StartHour int    `pulumi:"startHour"`
+	StartMin  int    `pulumi:"startMin"`
+}
+
+// TeamRoutingRuleTimeRestrictionRestrictionListInput is an input type that accepts TeamRoutingRuleTimeRestrictionRestrictionListArgs and TeamRoutingRuleTimeRestrictionRestrictionListOutput values.
+// You can construct a concrete instance of `TeamRoutingRuleTimeRestrictionRestrictionListInput` via:
+//
+//          TeamRoutingRuleTimeRestrictionRestrictionListArgs{...}
+type TeamRoutingRuleTimeRestrictionRestrictionListInput interface {
+	pulumi.Input
+
+	ToTeamRoutingRuleTimeRestrictionRestrictionListOutput() TeamRoutingRuleTimeRestrictionRestrictionListOutput
+	ToTeamRoutingRuleTimeRestrictionRestrictionListOutputWithContext(context.Context) TeamRoutingRuleTimeRestrictionRestrictionListOutput
+}
+
+type TeamRoutingRuleTimeRestrictionRestrictionListArgs struct {
+	EndDay    pulumi.StringInput `pulumi:"endDay"`
+	EndHour   pulumi.IntInput    `pulumi:"endHour"`
+	EndMin    pulumi.IntInput    `pulumi:"endMin"`
+	StartDay  pulumi.StringInput `pulumi:"startDay"`
+	StartHour pulumi.IntInput    `pulumi:"startHour"`
+	StartMin  pulumi.IntInput    `pulumi:"startMin"`
+}
+
+func (TeamRoutingRuleTimeRestrictionRestrictionListArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i TeamRoutingRuleTimeRestrictionRestrictionListArgs) ToTeamRoutingRuleTimeRestrictionRestrictionListOutput() TeamRoutingRuleTimeRestrictionRestrictionListOutput {
+	return i.ToTeamRoutingRuleTimeRestrictionRestrictionListOutputWithContext(context.Background())
+}
+
+func (i TeamRoutingRuleTimeRestrictionRestrictionListArgs) ToTeamRoutingRuleTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) TeamRoutingRuleTimeRestrictionRestrictionListOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TeamRoutingRuleTimeRestrictionRestrictionListOutput)
+}
+
+// TeamRoutingRuleTimeRestrictionRestrictionListArrayInput is an input type that accepts TeamRoutingRuleTimeRestrictionRestrictionListArray and TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput values.
+// You can construct a concrete instance of `TeamRoutingRuleTimeRestrictionRestrictionListArrayInput` via:
+//
+//          TeamRoutingRuleTimeRestrictionRestrictionListArray{ TeamRoutingRuleTimeRestrictionRestrictionListArgs{...} }
+type TeamRoutingRuleTimeRestrictionRestrictionListArrayInput interface {
+	pulumi.Input
+
+	ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutput() TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput
+	ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutputWithContext(context.Context) TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput
+}
+
+type TeamRoutingRuleTimeRestrictionRestrictionListArray []TeamRoutingRuleTimeRestrictionRestrictionListInput
+
+func (TeamRoutingRuleTimeRestrictionRestrictionListArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TeamRoutingRuleTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (i TeamRoutingRuleTimeRestrictionRestrictionListArray) ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutput() TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput {
+	return i.ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutputWithContext(context.Background())
+}
+
+func (i TeamRoutingRuleTimeRestrictionRestrictionListArray) ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput)
+}
+
+type TeamRoutingRuleTimeRestrictionRestrictionListOutput struct{ *pulumi.OutputState }
+
+func (TeamRoutingRuleTimeRestrictionRestrictionListOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) ToTeamRoutingRuleTimeRestrictionRestrictionListOutput() TeamRoutingRuleTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) ToTeamRoutingRuleTimeRestrictionRestrictionListOutputWithContext(ctx context.Context) TeamRoutingRuleTimeRestrictionRestrictionListOutput {
+	return o
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) EndDay() pulumi.StringOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) string { return v.EndDay }).(pulumi.StringOutput)
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) EndHour() pulumi.IntOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) int { return v.EndHour }).(pulumi.IntOutput)
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) EndMin() pulumi.IntOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) int { return v.EndMin }).(pulumi.IntOutput)
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) StartDay() pulumi.StringOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) string { return v.StartDay }).(pulumi.StringOutput)
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) StartHour() pulumi.IntOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) int { return v.StartHour }).(pulumi.IntOutput)
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListOutput) StartMin() pulumi.IntOutput {
+	return o.ApplyT(func(v TeamRoutingRuleTimeRestrictionRestrictionList) int { return v.StartMin }).(pulumi.IntOutput)
+}
+
+type TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput struct{ *pulumi.OutputState }
+
+func (TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TeamRoutingRuleTimeRestrictionRestrictionList)(nil)).Elem()
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput) ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutput() TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput) ToTeamRoutingRuleTimeRestrictionRestrictionListArrayOutputWithContext(ctx context.Context) TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput {
+	return o
+}
+
+func (o TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput) Index(i pulumi.IntInput) TeamRoutingRuleTimeRestrictionRestrictionListOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TeamRoutingRuleTimeRestrictionRestrictionList {
+		return vs[0].([]TeamRoutingRuleTimeRestrictionRestrictionList)[vs[1].(int)]
+	}).(TeamRoutingRuleTimeRestrictionRestrictionListOutput)
 }
 
 type UserUserAddress struct {
@@ -8204,6 +8699,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*AlertPolicyTimeRestrictionArrayInput)(nil)).Elem(), AlertPolicyTimeRestrictionArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionInput)(nil)).Elem(), AlertPolicyTimeRestrictionRestrictionArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionArrayInput)(nil)).Elem(), AlertPolicyTimeRestrictionRestrictionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionListInput)(nil)).Elem(), AlertPolicyTimeRestrictionRestrictionListArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*AlertPolicyTimeRestrictionRestrictionListArrayInput)(nil)).Elem(), AlertPolicyTimeRestrictionRestrictionListArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ApiIntegrationResponderInput)(nil)).Elem(), ApiIntegrationResponderArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ApiIntegrationResponderArrayInput)(nil)).Elem(), ApiIntegrationResponderArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*EmailIntegrationResponderInput)(nil)).Elem(), EmailIntegrationResponderArgs{})
@@ -8278,6 +8775,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationPolicyTimeRestrictionArrayInput)(nil)).Elem(), NotificationPolicyTimeRestrictionArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionInput)(nil)).Elem(), NotificationPolicyTimeRestrictionRestrictionArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionArrayInput)(nil)).Elem(), NotificationPolicyTimeRestrictionRestrictionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionListInput)(nil)).Elem(), NotificationPolicyTimeRestrictionRestrictionListArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NotificationPolicyTimeRestrictionRestrictionListArrayInput)(nil)).Elem(), NotificationPolicyTimeRestrictionRestrictionListArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationRuleCriteriaInput)(nil)).Elem(), NotificationRuleCriteriaArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationRuleCriteriaArrayInput)(nil)).Elem(), NotificationRuleCriteriaArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*NotificationRuleCriteriaConditionInput)(nil)).Elem(), NotificationRuleCriteriaConditionArgs{})
@@ -8300,6 +8799,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ScheduleRotationTimeRestrictionArrayInput)(nil)).Elem(), ScheduleRotationTimeRestrictionArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionInput)(nil)).Elem(), ScheduleRotationTimeRestrictionRestrictionArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionArrayInput)(nil)).Elem(), ScheduleRotationTimeRestrictionRestrictionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionListInput)(nil)).Elem(), ScheduleRotationTimeRestrictionRestrictionListArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ScheduleRotationTimeRestrictionRestrictionListArrayInput)(nil)).Elem(), ScheduleRotationTimeRestrictionRestrictionListArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceIncidentRuleIncidentRuleInput)(nil)).Elem(), ServiceIncidentRuleIncidentRuleArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceIncidentRuleIncidentRuleArrayInput)(nil)).Elem(), ServiceIncidentRuleIncidentRuleArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceIncidentRuleIncidentRuleConditionInput)(nil)).Elem(), ServiceIncidentRuleIncidentRuleConditionArgs{})
@@ -8320,6 +8821,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*TeamRoutingRuleTimeRestrictionArrayInput)(nil)).Elem(), TeamRoutingRuleTimeRestrictionArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionInput)(nil)).Elem(), TeamRoutingRuleTimeRestrictionRestrictionArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionArrayInput)(nil)).Elem(), TeamRoutingRuleTimeRestrictionRestrictionArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionListInput)(nil)).Elem(), TeamRoutingRuleTimeRestrictionRestrictionListArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TeamRoutingRuleTimeRestrictionRestrictionListArrayInput)(nil)).Elem(), TeamRoutingRuleTimeRestrictionRestrictionListArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*UserUserAddressInput)(nil)).Elem(), UserUserAddressArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*UserUserAddressArrayInput)(nil)).Elem(), UserUserAddressArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetEscalationRepeatInput)(nil)).Elem(), GetEscalationRepeatArgs{})
@@ -8340,6 +8843,8 @@ func init() {
 	pulumi.RegisterOutputType(AlertPolicyTimeRestrictionArrayOutput{})
 	pulumi.RegisterOutputType(AlertPolicyTimeRestrictionRestrictionOutput{})
 	pulumi.RegisterOutputType(AlertPolicyTimeRestrictionRestrictionArrayOutput{})
+	pulumi.RegisterOutputType(AlertPolicyTimeRestrictionRestrictionListOutput{})
+	pulumi.RegisterOutputType(AlertPolicyTimeRestrictionRestrictionListArrayOutput{})
 	pulumi.RegisterOutputType(ApiIntegrationResponderOutput{})
 	pulumi.RegisterOutputType(ApiIntegrationResponderArrayOutput{})
 	pulumi.RegisterOutputType(EmailIntegrationResponderOutput{})
@@ -8414,6 +8919,8 @@ func init() {
 	pulumi.RegisterOutputType(NotificationPolicyTimeRestrictionArrayOutput{})
 	pulumi.RegisterOutputType(NotificationPolicyTimeRestrictionRestrictionOutput{})
 	pulumi.RegisterOutputType(NotificationPolicyTimeRestrictionRestrictionArrayOutput{})
+	pulumi.RegisterOutputType(NotificationPolicyTimeRestrictionRestrictionListOutput{})
+	pulumi.RegisterOutputType(NotificationPolicyTimeRestrictionRestrictionListArrayOutput{})
 	pulumi.RegisterOutputType(NotificationRuleCriteriaOutput{})
 	pulumi.RegisterOutputType(NotificationRuleCriteriaArrayOutput{})
 	pulumi.RegisterOutputType(NotificationRuleCriteriaConditionOutput{})
@@ -8436,6 +8943,8 @@ func init() {
 	pulumi.RegisterOutputType(ScheduleRotationTimeRestrictionArrayOutput{})
 	pulumi.RegisterOutputType(ScheduleRotationTimeRestrictionRestrictionOutput{})
 	pulumi.RegisterOutputType(ScheduleRotationTimeRestrictionRestrictionArrayOutput{})
+	pulumi.RegisterOutputType(ScheduleRotationTimeRestrictionRestrictionListOutput{})
+	pulumi.RegisterOutputType(ScheduleRotationTimeRestrictionRestrictionListArrayOutput{})
 	pulumi.RegisterOutputType(ServiceIncidentRuleIncidentRuleOutput{})
 	pulumi.RegisterOutputType(ServiceIncidentRuleIncidentRuleArrayOutput{})
 	pulumi.RegisterOutputType(ServiceIncidentRuleIncidentRuleConditionOutput{})
@@ -8456,6 +8965,8 @@ func init() {
 	pulumi.RegisterOutputType(TeamRoutingRuleTimeRestrictionArrayOutput{})
 	pulumi.RegisterOutputType(TeamRoutingRuleTimeRestrictionRestrictionOutput{})
 	pulumi.RegisterOutputType(TeamRoutingRuleTimeRestrictionRestrictionArrayOutput{})
+	pulumi.RegisterOutputType(TeamRoutingRuleTimeRestrictionRestrictionListOutput{})
+	pulumi.RegisterOutputType(TeamRoutingRuleTimeRestrictionRestrictionListArrayOutput{})
 	pulumi.RegisterOutputType(UserUserAddressOutput{})
 	pulumi.RegisterOutputType(UserUserAddressArrayOutput{})
 	pulumi.RegisterOutputType(GetEscalationRepeatOutput{})

--- a/sdk/go/opsgenie/teamRoutingRule.go
+++ b/sdk/go/opsgenie/teamRoutingRule.go
@@ -63,8 +63,8 @@ import (
 // 			TeamId: testTeam.ID(),
 // 			TimeRestrictions: TeamRoutingRuleTimeRestrictionArray{
 // 				&TeamRoutingRuleTimeRestrictionArgs{
-// 					Restrictions: TeamRoutingRuleTimeRestrictionRestrictionArray{
-// 						&TeamRoutingRuleTimeRestrictionRestrictionArgs{
+// 					RestrictionList: TeamRoutingRuleTimeRestrictionRestrictionListArray{
+// 						&TeamRoutingRuleTimeRestrictionRestrictionListArgs{
 // 							EndDay:    pulumi.String("tuesday"),
 // 							EndHour:   pulumi.Int(18),
 // 							EndMin:    pulumi.Int(30),

--- a/sdk/nodejs/alertPolicy.ts
+++ b/sdk/nodejs/alertPolicy.ts
@@ -22,7 +22,7 @@ import * as utilities from "./utilities";
  *     filters: [{}],
  *     timeRestrictions: [{
  *         type: "weekday-and-time-of-day",
- *         restrictions: [
+ *         restrictionList: [
  *             {
  *                 endDay: "monday",
  *                 endHour: 7,

--- a/sdk/nodejs/go.mod
+++ b/sdk/nodejs/go.mod
@@ -1,0 +1,3 @@
+module fake_nodejs_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/nodejs/teamRoutingRule.ts
+++ b/sdk/nodejs/teamRoutingRule.ts
@@ -39,7 +39,7 @@ import * as utilities from "./utilities";
  *     order: 0,
  *     teamId: testTeam.id,
  *     timeRestrictions: [{
- *         restrictions: [{
+ *         restrictionList: [{
  *             endDay: "tuesday",
  *             endHour: 18,
  *             endMin: 30,

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -63,9 +63,13 @@ export interface AlertPolicyResponder {
 
 export interface AlertPolicyTimeRestriction {
     /**
+     * A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+     */
+    restriction?: pulumi.Input<pulumi.Input<inputs.AlertPolicyTimeRestrictionRestriction>[]>;
+    /**
      * List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
      */
-    restrictions?: pulumi.Input<pulumi.Input<inputs.AlertPolicyTimeRestrictionRestriction>[]>;
+    restrictionList?: pulumi.Input<pulumi.Input<inputs.AlertPolicyTimeRestrictionRestrictionList>[]>;
     /**
      * Type of responder. Acceptable values are: `user` or `team`
      */
@@ -73,6 +77,25 @@ export interface AlertPolicyTimeRestriction {
 }
 
 export interface AlertPolicyTimeRestrictionRestriction {
+    /**
+     * Ending hour of restriction.
+     */
+    endHour: pulumi.Input<number>;
+    /**
+     * Ending minute of restriction on defined `endHour`
+     */
+    endMin: pulumi.Input<number>;
+    /**
+     * Starting hour of restriction.
+     */
+    startHour: pulumi.Input<number>;
+    /**
+     * Staring minute of restriction on defined `startHour`
+     */
+    startMin: pulumi.Input<number>;
+}
+
+export interface AlertPolicyTimeRestrictionRestrictionList {
     /**
      * Ending day of restriction (eg. `wednesday`)
      */
@@ -169,18 +192,18 @@ export interface GetEscalationRepeatArgs {
     waitInterval?: pulumi.Input<number>;
 }
 
-export interface GetEscalationRuleArgs {
-    condition: pulumi.Input<string>;
-    delay: pulumi.Input<number>;
-    notifyType: pulumi.Input<string>;
-    recipients: pulumi.Input<pulumi.Input<inputs.GetEscalationRuleRecipientArgs>[]>;
-}
-
 export interface GetEscalationRule {
     condition: string;
     delay: number;
     notifyType: string;
     recipients: inputs.GetEscalationRuleRecipient[];
+}
+
+export interface GetEscalationRuleArgs {
+    condition: pulumi.Input<string>;
+    delay: pulumi.Input<number>;
+    notifyType: pulumi.Input<string>;
+    recipients: pulumi.Input<pulumi.Input<inputs.GetEscalationRuleRecipientArgs>[]>;
 }
 
 export interface GetEscalationRuleRecipientArgs {
@@ -199,20 +222,20 @@ export interface GetEscalationRuleRecipient {
     type?: string;
 }
 
-export interface GetTeamMember {
-    /**
-     * The ID of the Opsgenie Team.
-     */
-    id?: string;
-    role?: string;
-}
-
 export interface GetTeamMemberArgs {
     /**
      * The ID of the Opsgenie Team.
      */
     id?: pulumi.Input<string>;
     role?: pulumi.Input<string>;
+}
+
+export interface GetTeamMember {
+    /**
+     * The ID of the Opsgenie Team.
+     */
+    id?: string;
+    role?: string;
 }
 
 export interface IncidentTemplateStakeholderProperty {
@@ -727,7 +750,7 @@ export interface NotificationPolicyTimeRestriction {
     /**
      * List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
      */
-    restrictions?: pulumi.Input<pulumi.Input<inputs.NotificationPolicyTimeRestrictionRestriction>[]>;
+    restrictionList?: pulumi.Input<pulumi.Input<inputs.NotificationPolicyTimeRestrictionRestrictionList>[]>;
     /**
      * Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
      */
@@ -735,6 +758,25 @@ export interface NotificationPolicyTimeRestriction {
 }
 
 export interface NotificationPolicyTimeRestrictionRestriction {
+    /**
+     * Ending hour of restriction.
+     */
+    endHour: pulumi.Input<number>;
+    /**
+     * Ending minute of restriction on defined `endHour`
+     */
+    endMin: pulumi.Input<number>;
+    /**
+     * Starting hour of restriction.
+     */
+    startHour: pulumi.Input<number>;
+    /**
+     * Staring minute of restriction on defined `startHour`
+     */
+    startMin: pulumi.Input<number>;
+}
+
+export interface NotificationPolicyTimeRestrictionRestrictionList {
     /**
      * Ending day of restriction (eg. `wednesday`)
      */
@@ -880,7 +922,7 @@ export interface ScheduleRotationTimeRestriction {
     /**
      * It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
      */
-    restrictions?: pulumi.Input<pulumi.Input<inputs.ScheduleRotationTimeRestrictionRestriction>[]>;
+    restrictionList?: pulumi.Input<pulumi.Input<inputs.ScheduleRotationTimeRestrictionRestrictionList>[]>;
     /**
      * This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
      */
@@ -888,6 +930,25 @@ export interface ScheduleRotationTimeRestriction {
 }
 
 export interface ScheduleRotationTimeRestrictionRestriction {
+    /**
+     * Value of the hour that frame will end.
+     */
+    endHour: pulumi.Input<number>;
+    /**
+     * Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+     */
+    endMin: pulumi.Input<number>;
+    /**
+     * Value of the hour that frame will start.
+     */
+    startHour: pulumi.Input<number>;
+    /**
+     * Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+     */
+    startMin: pulumi.Input<number>;
+}
+
+export interface ScheduleRotationTimeRestrictionRestrictionList {
     /**
      * Value of the day that frame will end.
      */
@@ -1051,11 +1112,18 @@ export interface TeamRoutingRuleNotify {
 
 export interface TeamRoutingRuleTimeRestriction {
     restriction?: pulumi.Input<pulumi.Input<inputs.TeamRoutingRuleTimeRestrictionRestriction>[]>;
-    restrictions?: pulumi.Input<pulumi.Input<inputs.TeamRoutingRuleTimeRestrictionRestriction>[]>;
+    restrictionList?: pulumi.Input<pulumi.Input<inputs.TeamRoutingRuleTimeRestrictionRestrictionList>[]>;
     type: pulumi.Input<string>;
 }
 
 export interface TeamRoutingRuleTimeRestrictionRestriction {
+    endHour: pulumi.Input<number>;
+    endMin: pulumi.Input<number>;
+    startHour: pulumi.Input<number>;
+    startMin: pulumi.Input<number>;
+}
+
+export interface TeamRoutingRuleTimeRestrictionRestrictionList {
     endDay: pulumi.Input<string>;
     endHour: pulumi.Input<number>;
     endMin: pulumi.Input<number>;
@@ -1071,4 +1139,3 @@ export interface UserUserAddress {
     state: pulumi.Input<string>;
     zipcode: pulumi.Input<string>;
 }
-

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -63,9 +63,13 @@ export interface AlertPolicyResponder {
 
 export interface AlertPolicyTimeRestriction {
     /**
+     * A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+     */
+    restriction?: outputs.AlertPolicyTimeRestrictionRestriction[];
+    /**
      * List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
      */
-    restrictions?: outputs.AlertPolicyTimeRestrictionRestriction[];
+    restrictionList?: outputs.AlertPolicyTimeRestrictionRestrictionList[];
     /**
      * Type of responder. Acceptable values are: `user` or `team`
      */
@@ -73,6 +77,25 @@ export interface AlertPolicyTimeRestriction {
 }
 
 export interface AlertPolicyTimeRestrictionRestriction {
+    /**
+     * Ending hour of restriction.
+     */
+    endHour: number;
+    /**
+     * Ending minute of restriction on defined `endHour`
+     */
+    endMin: number;
+    /**
+     * Starting hour of restriction.
+     */
+    startHour: number;
+    /**
+     * Staring minute of restriction on defined `startHour`
+     */
+    startMin: number;
+}
+
+export interface AlertPolicyTimeRestrictionRestrictionList {
     /**
      * Ending day of restriction (eg. `wednesday`)
      */
@@ -697,7 +720,7 @@ export interface NotificationPolicyTimeRestriction {
     /**
      * List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
      */
-    restrictions?: outputs.NotificationPolicyTimeRestrictionRestriction[];
+    restrictionList?: outputs.NotificationPolicyTimeRestrictionRestrictionList[];
     /**
      * Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
      */
@@ -705,6 +728,25 @@ export interface NotificationPolicyTimeRestriction {
 }
 
 export interface NotificationPolicyTimeRestrictionRestriction {
+    /**
+     * Ending hour of restriction.
+     */
+    endHour: number;
+    /**
+     * Ending minute of restriction on defined `endHour`
+     */
+    endMin: number;
+    /**
+     * Starting hour of restriction.
+     */
+    startHour: number;
+    /**
+     * Staring minute of restriction on defined `startHour`
+     */
+    startMin: number;
+}
+
+export interface NotificationPolicyTimeRestrictionRestrictionList {
     /**
      * Ending day of restriction (eg. `wednesday`)
      */
@@ -850,7 +892,7 @@ export interface ScheduleRotationTimeRestriction {
     /**
      * It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
      */
-    restrictions?: outputs.ScheduleRotationTimeRestrictionRestriction[];
+    restrictionList?: outputs.ScheduleRotationTimeRestrictionRestrictionList[];
     /**
      * This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
      */
@@ -858,6 +900,25 @@ export interface ScheduleRotationTimeRestriction {
 }
 
 export interface ScheduleRotationTimeRestrictionRestriction {
+    /**
+     * Value of the hour that frame will end.
+     */
+    endHour: number;
+    /**
+     * Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+     */
+    endMin: number;
+    /**
+     * Value of the hour that frame will start.
+     */
+    startHour: number;
+    /**
+     * Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+     */
+    startMin: number;
+}
+
+export interface ScheduleRotationTimeRestrictionRestrictionList {
     /**
      * Value of the day that frame will end.
      */
@@ -1021,11 +1082,18 @@ export interface TeamRoutingRuleNotify {
 
 export interface TeamRoutingRuleTimeRestriction {
     restriction?: outputs.TeamRoutingRuleTimeRestrictionRestriction[];
-    restrictions?: outputs.TeamRoutingRuleTimeRestrictionRestriction[];
+    restrictionList?: outputs.TeamRoutingRuleTimeRestrictionRestrictionList[];
     type: string;
 }
 
 export interface TeamRoutingRuleTimeRestrictionRestriction {
+    endHour: number;
+    endMin: number;
+    startHour: number;
+    startMin: number;
+}
+
+export interface TeamRoutingRuleTimeRestrictionRestrictionList {
     endDay: string;
     endHour: number;
     endMin: number;
@@ -1041,4 +1109,3 @@ export interface UserUserAddress {
     state: string;
     zipcode: string;
 }
-

--- a/sdk/python/go.mod
+++ b/sdk/python/go.mod
@@ -1,0 +1,3 @@
+module fake_python_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/python/pulumi_opsgenie/_inputs.py
+++ b/sdk/python/pulumi_opsgenie/_inputs.py
@@ -14,6 +14,7 @@ __all__ = [
     'AlertPolicyResponderArgs',
     'AlertPolicyTimeRestrictionArgs',
     'AlertPolicyTimeRestrictionRestrictionArgs',
+    'AlertPolicyTimeRestrictionRestrictionListArgs',
     'ApiIntegrationResponderArgs',
     'EmailIntegrationResponderArgs',
     'EscalationRepeatArgs',
@@ -51,6 +52,7 @@ __all__ = [
     'NotificationPolicyFilterConditionArgs',
     'NotificationPolicyTimeRestrictionArgs',
     'NotificationPolicyTimeRestrictionRestrictionArgs',
+    'NotificationPolicyTimeRestrictionRestrictionListArgs',
     'NotificationRuleCriteriaArgs',
     'NotificationRuleCriteriaConditionArgs',
     'NotificationRuleRepeatArgs',
@@ -62,6 +64,7 @@ __all__ = [
     'ScheduleRotationParticipantArgs',
     'ScheduleRotationTimeRestrictionArgs',
     'ScheduleRotationTimeRestrictionRestrictionArgs',
+    'ScheduleRotationTimeRestrictionRestrictionListArgs',
     'ServiceIncidentRuleIncidentRuleArgs',
     'ServiceIncidentRuleIncidentRuleConditionArgs',
     'ServiceIncidentRuleIncidentRuleIncidentPropertyArgs',
@@ -72,6 +75,7 @@ __all__ = [
     'TeamRoutingRuleNotifyArgs',
     'TeamRoutingRuleTimeRestrictionArgs',
     'TeamRoutingRuleTimeRestrictionRestrictionArgs',
+    'TeamRoutingRuleTimeRestrictionRestrictionListArgs',
     'UserUserAddressArgs',
     'GetEscalationRepeatArgs',
     'GetEscalationRuleArgs',
@@ -292,14 +296,18 @@ class AlertPolicyResponderArgs:
 class AlertPolicyTimeRestrictionArgs:
     def __init__(__self__, *,
                  type: pulumi.Input[str],
-                 restrictions: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]] = None):
+                 restriction: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]] = None,
+                 restriction_list: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionListArgs']]]] = None):
         """
         :param pulumi.Input[str] type: Type of responder. Acceptable values are: `user` or `team`
-        :param pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]] restrictions: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
+        :param pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]] restriction: A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        :param pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionListArgs']]] restriction_list: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
         pulumi.set(__self__, "type", type)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction is not None:
+            pulumi.set(__self__, "restriction", restriction)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -315,19 +323,98 @@ class AlertPolicyTimeRestrictionArgs:
 
     @property
     @pulumi.getter
-    def restrictions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]]:
+    def restriction(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]]:
+        """
+        A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        """
+        return pulumi.get(self, "restriction")
+
+    @restriction.setter
+    def restriction(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]]):
+        pulumi.set(self, "restriction", value)
+
+    @property
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionListArgs']]]]:
         """
         List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
-    @restrictions.setter
-    def restrictions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionArgs']]]]):
-        pulumi.set(self, "restrictions", value)
+    @restriction_list.setter
+    def restriction_list(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['AlertPolicyTimeRestrictionRestrictionListArgs']]]]):
+        pulumi.set(self, "restriction_list", value)
 
 
 @pulumi.input_type
 class AlertPolicyTimeRestrictionRestrictionArgs:
+    def __init__(__self__, *,
+                 end_hour: pulumi.Input[int],
+                 end_min: pulumi.Input[int],
+                 start_hour: pulumi.Input[int],
+                 start_min: pulumi.Input[int]):
+        """
+        :param pulumi.Input[int] end_hour: Ending hour of restriction.
+        :param pulumi.Input[int] end_min: Ending minute of restriction on defined `end_hour`
+        :param pulumi.Input[int] start_hour: Starting hour of restriction.
+        :param pulumi.Input[int] start_min: Staring minute of restriction on defined `start_hour`
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> pulumi.Input[int]:
+        """
+        Ending hour of restriction.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @end_hour.setter
+    def end_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_hour", value)
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> pulumi.Input[int]:
+        """
+        Ending minute of restriction on defined `end_hour`
+        """
+        return pulumi.get(self, "end_min")
+
+    @end_min.setter
+    def end_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_min", value)
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> pulumi.Input[int]:
+        """
+        Starting hour of restriction.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @start_hour.setter
+    def start_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_hour", value)
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> pulumi.Input[int]:
+        """
+        Staring minute of restriction on defined `start_hour`
+        """
+        return pulumi.get(self, "start_min")
+
+    @start_min.setter
+    def start_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_min", value)
+
+
+@pulumi.input_type
+class AlertPolicyTimeRestrictionRestrictionListArgs:
     def __init__(__self__, *,
                  end_day: pulumi.Input[str],
                  end_hour: pulumi.Input[int],
@@ -2740,17 +2827,17 @@ class NotificationPolicyTimeRestrictionArgs:
     def __init__(__self__, *,
                  type: pulumi.Input[str],
                  restriction: Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]]] = None,
-                 restrictions: Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]]] = None):
+                 restriction_list: Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionListArgs']]]] = None):
         """
         :param pulumi.Input[str] type: Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
         :param pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]] restriction: A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
-        :param pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]] restrictions: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
+        :param pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionListArgs']]] restriction_list: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -2777,20 +2864,87 @@ class NotificationPolicyTimeRestrictionArgs:
         pulumi.set(self, "restriction", value)
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]]]:
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionListArgs']]]]:
         """
         List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
-    @restrictions.setter
-    def restrictions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionArgs']]]]):
-        pulumi.set(self, "restrictions", value)
+    @restriction_list.setter
+    def restriction_list(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NotificationPolicyTimeRestrictionRestrictionListArgs']]]]):
+        pulumi.set(self, "restriction_list", value)
 
 
 @pulumi.input_type
 class NotificationPolicyTimeRestrictionRestrictionArgs:
+    def __init__(__self__, *,
+                 end_hour: pulumi.Input[int],
+                 end_min: pulumi.Input[int],
+                 start_hour: pulumi.Input[int],
+                 start_min: pulumi.Input[int]):
+        """
+        :param pulumi.Input[int] end_hour: Ending hour of restriction.
+        :param pulumi.Input[int] end_min: Ending minute of restriction on defined `end_hour`
+        :param pulumi.Input[int] start_hour: Starting hour of restriction.
+        :param pulumi.Input[int] start_min: Staring minute of restriction on defined `start_hour`
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> pulumi.Input[int]:
+        """
+        Ending hour of restriction.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @end_hour.setter
+    def end_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_hour", value)
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> pulumi.Input[int]:
+        """
+        Ending minute of restriction on defined `end_hour`
+        """
+        return pulumi.get(self, "end_min")
+
+    @end_min.setter
+    def end_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_min", value)
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> pulumi.Input[int]:
+        """
+        Starting hour of restriction.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @start_hour.setter
+    def start_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_hour", value)
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> pulumi.Input[int]:
+        """
+        Staring minute of restriction on defined `start_hour`
+        """
+        return pulumi.get(self, "start_min")
+
+    @start_min.setter
+    def start_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_min", value)
+
+
+@pulumi.input_type
+class NotificationPolicyTimeRestrictionRestrictionListArgs:
     def __init__(__self__, *,
                  end_day: pulumi.Input[str],
                  end_hour: pulumi.Input[int],
@@ -3335,17 +3489,17 @@ class ScheduleRotationTimeRestrictionArgs:
     def __init__(__self__, *,
                  type: pulumi.Input[str],
                  restriction: Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]]] = None,
-                 restrictions: Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]]] = None):
+                 restriction_list: Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionListArgs']]]] = None):
         """
         :param pulumi.Input[str] type: This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
         :param pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]] restriction: It is a restriction object which is described below. In this case startDay/endDay fields are not supported. This can be used only if time restriction type is `time-of-day`.
-        :param pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]] restrictions: It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
+        :param pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionListArgs']]] restriction_list: It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         """
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -3372,20 +3526,87 @@ class ScheduleRotationTimeRestrictionArgs:
         pulumi.set(self, "restriction", value)
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]]]:
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionListArgs']]]]:
         """
         It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
-    @restrictions.setter
-    def restrictions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionArgs']]]]):
-        pulumi.set(self, "restrictions", value)
+    @restriction_list.setter
+    def restriction_list(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ScheduleRotationTimeRestrictionRestrictionListArgs']]]]):
+        pulumi.set(self, "restriction_list", value)
 
 
 @pulumi.input_type
 class ScheduleRotationTimeRestrictionRestrictionArgs:
+    def __init__(__self__, *,
+                 end_hour: pulumi.Input[int],
+                 end_min: pulumi.Input[int],
+                 start_hour: pulumi.Input[int],
+                 start_min: pulumi.Input[int]):
+        """
+        :param pulumi.Input[int] end_hour: Value of the hour that frame will end.
+        :param pulumi.Input[int] end_min: Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        :param pulumi.Input[int] start_hour: Value of the hour that frame will start.
+        :param pulumi.Input[int] start_min: Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> pulumi.Input[int]:
+        """
+        Value of the hour that frame will end.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @end_hour.setter
+    def end_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_hour", value)
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> pulumi.Input[int]:
+        """
+        Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        return pulumi.get(self, "end_min")
+
+    @end_min.setter
+    def end_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_min", value)
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> pulumi.Input[int]:
+        """
+        Value of the hour that frame will start.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @start_hour.setter
+    def start_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_hour", value)
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> pulumi.Input[int]:
+        """
+        Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        return pulumi.get(self, "start_min")
+
+    @start_min.setter
+    def start_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_min", value)
+
+
+@pulumi.input_type
+class ScheduleRotationTimeRestrictionRestrictionListArgs:
     def __init__(__self__, *,
                  end_day: pulumi.Input[str],
                  end_hour: pulumi.Input[int],
@@ -3998,12 +4219,12 @@ class TeamRoutingRuleTimeRestrictionArgs:
     def __init__(__self__, *,
                  type: pulumi.Input[str],
                  restriction: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionArgs']]]] = None,
-                 restrictions: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionArgs']]]] = None):
+                 restriction_list: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionListArgs']]]] = None):
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -4024,17 +4245,66 @@ class TeamRoutingRuleTimeRestrictionArgs:
         pulumi.set(self, "restriction", value)
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionArgs']]]]:
-        return pulumi.get(self, "restrictions")
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionListArgs']]]]:
+        return pulumi.get(self, "restriction_list")
 
-    @restrictions.setter
-    def restrictions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionArgs']]]]):
-        pulumi.set(self, "restrictions", value)
+    @restriction_list.setter
+    def restriction_list(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRoutingRuleTimeRestrictionRestrictionListArgs']]]]):
+        pulumi.set(self, "restriction_list", value)
 
 
 @pulumi.input_type
 class TeamRoutingRuleTimeRestrictionRestrictionArgs:
+    def __init__(__self__, *,
+                 end_hour: pulumi.Input[int],
+                 end_min: pulumi.Input[int],
+                 start_hour: pulumi.Input[int],
+                 start_min: pulumi.Input[int]):
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> pulumi.Input[int]:
+        return pulumi.get(self, "end_hour")
+
+    @end_hour.setter
+    def end_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_hour", value)
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> pulumi.Input[int]:
+        return pulumi.get(self, "end_min")
+
+    @end_min.setter
+    def end_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "end_min", value)
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> pulumi.Input[int]:
+        return pulumi.get(self, "start_hour")
+
+    @start_hour.setter
+    def start_hour(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_hour", value)
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> pulumi.Input[int]:
+        return pulumi.get(self, "start_min")
+
+    @start_min.setter
+    def start_min(self, value: pulumi.Input[int]):
+        pulumi.set(self, "start_min", value)
+
+
+@pulumi.input_type
+class TeamRoutingRuleTimeRestrictionRestrictionListArgs:
     def __init__(__self__, *,
                  end_day: pulumi.Input[str],
                  end_hour: pulumi.Input[int],

--- a/sdk/python/pulumi_opsgenie/alert_policy.py
+++ b/sdk/python/pulumi_opsgenie/alert_policy.py
@@ -710,8 +710,8 @@ class AlertPolicy(pulumi.CustomResource):
             filters=[opsgenie.AlertPolicyFilterArgs()],
             time_restrictions=[opsgenie.AlertPolicyTimeRestrictionArgs(
                 type="weekday-and-time-of-day",
-                restrictions=[
-                    opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(
+                restriction_list=[
+                    opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(
                         end_day="monday",
                         end_hour=7,
                         end_min=0,
@@ -719,7 +719,7 @@ class AlertPolicy(pulumi.CustomResource):
                         start_hour=21,
                         start_min=0,
                     ),
-                    opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(
+                    opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(
                         end_day="tuesday",
                         end_hour=7,
                         end_min=0,
@@ -791,8 +791,8 @@ class AlertPolicy(pulumi.CustomResource):
             filters=[opsgenie.AlertPolicyFilterArgs()],
             time_restrictions=[opsgenie.AlertPolicyTimeRestrictionArgs(
                 type="weekday-and-time-of-day",
-                restrictions=[
-                    opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(
+                restriction_list=[
+                    opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(
                         end_day="monday",
                         end_hour=7,
                         end_min=0,
@@ -800,7 +800,7 @@ class AlertPolicy(pulumi.CustomResource):
                         start_hour=21,
                         start_min=0,
                     ),
-                    opsgenie.AlertPolicyTimeRestrictionRestrictionArgs(
+                    opsgenie.AlertPolicyTimeRestrictionRestrictionListArgs(
                         end_day="tuesday",
                         end_hour=7,
                         end_min=0,

--- a/sdk/python/pulumi_opsgenie/outputs.py
+++ b/sdk/python/pulumi_opsgenie/outputs.py
@@ -15,6 +15,7 @@ __all__ = [
     'AlertPolicyResponder',
     'AlertPolicyTimeRestriction',
     'AlertPolicyTimeRestrictionRestriction',
+    'AlertPolicyTimeRestrictionRestrictionList',
     'ApiIntegrationResponder',
     'EmailIntegrationResponder',
     'EscalationRepeat',
@@ -52,6 +53,7 @@ __all__ = [
     'NotificationPolicyFilterCondition',
     'NotificationPolicyTimeRestriction',
     'NotificationPolicyTimeRestrictionRestriction',
+    'NotificationPolicyTimeRestrictionRestrictionList',
     'NotificationRuleCriteria',
     'NotificationRuleCriteriaCondition',
     'NotificationRuleRepeat',
@@ -63,6 +65,7 @@ __all__ = [
     'ScheduleRotationParticipant',
     'ScheduleRotationTimeRestriction',
     'ScheduleRotationTimeRestrictionRestriction',
+    'ScheduleRotationTimeRestrictionRestrictionList',
     'ServiceIncidentRuleIncidentRule',
     'ServiceIncidentRuleIncidentRuleCondition',
     'ServiceIncidentRuleIncidentRuleIncidentProperty',
@@ -73,6 +76,7 @@ __all__ = [
     'TeamRoutingRuleNotify',
     'TeamRoutingRuleTimeRestriction',
     'TeamRoutingRuleTimeRestrictionRestriction',
+    'TeamRoutingRuleTimeRestrictionRestrictionList',
     'UserUserAddress',
     'GetEscalationRepeatResult',
     'GetEscalationRuleResult',
@@ -262,16 +266,37 @@ class AlertPolicyResponder(dict):
 
 @pulumi.output_type
 class AlertPolicyTimeRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "restrictionList":
+            suggest = "restriction_list"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in AlertPolicyTimeRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        AlertPolicyTimeRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        AlertPolicyTimeRestriction.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  type: str,
-                 restrictions: Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestriction']] = None):
+                 restriction: Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestriction']] = None,
+                 restriction_list: Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestrictionList']] = None):
         """
         :param str type: Type of responder. Acceptable values are: `user` or `team`
-        :param Sequence['AlertPolicyTimeRestrictionRestrictionArgs'] restrictions: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
+        :param Sequence['AlertPolicyTimeRestrictionRestrictionArgs'] restriction: A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        :param Sequence['AlertPolicyTimeRestrictionRestrictionListArgs'] restriction_list: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
         pulumi.set(__self__, "type", type)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction is not None:
+            pulumi.set(__self__, "restriction", restriction)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -283,15 +308,97 @@ class AlertPolicyTimeRestriction(dict):
 
     @property
     @pulumi.getter
-    def restrictions(self) -> Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestriction']]:
+    def restriction(self) -> Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestriction']]:
+        """
+        A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
+        """
+        return pulumi.get(self, "restriction")
+
+    @property
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[Sequence['outputs.AlertPolicyTimeRestrictionRestrictionList']]:
         """
         List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
 
 @pulumi.output_type
 class AlertPolicyTimeRestrictionRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "endHour":
+            suggest = "end_hour"
+        elif key == "endMin":
+            suggest = "end_min"
+        elif key == "startHour":
+            suggest = "start_hour"
+        elif key == "startMin":
+            suggest = "start_min"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in AlertPolicyTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        AlertPolicyTimeRestrictionRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        AlertPolicyTimeRestrictionRestriction.__key_warning(key)
+        return super().get(key, default)
+
+    def __init__(__self__, *,
+                 end_hour: int,
+                 end_min: int,
+                 start_hour: int,
+                 start_min: int):
+        """
+        :param int end_hour: Ending hour of restriction.
+        :param int end_min: Ending minute of restriction on defined `end_hour`
+        :param int start_hour: Starting hour of restriction.
+        :param int start_min: Staring minute of restriction on defined `start_hour`
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> int:
+        """
+        Ending hour of restriction.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> int:
+        """
+        Ending minute of restriction on defined `end_hour`
+        """
+        return pulumi.get(self, "end_min")
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> int:
+        """
+        Starting hour of restriction.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> int:
+        """
+        Staring minute of restriction on defined `start_hour`
+        """
+        return pulumi.get(self, "start_min")
+
+
+@pulumi.output_type
+class AlertPolicyTimeRestrictionRestrictionList(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
@@ -309,14 +416,14 @@ class AlertPolicyTimeRestrictionRestriction(dict):
             suggest = "start_min"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in AlertPolicyTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in AlertPolicyTimeRestrictionRestrictionList. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        AlertPolicyTimeRestrictionRestriction.__key_warning(key)
+        AlertPolicyTimeRestrictionRestrictionList.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        AlertPolicyTimeRestrictionRestriction.__key_warning(key)
+        AlertPolicyTimeRestrictionRestrictionList.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,
@@ -2479,20 +2586,37 @@ class NotificationPolicyFilterCondition(dict):
 
 @pulumi.output_type
 class NotificationPolicyTimeRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "restrictionList":
+            suggest = "restriction_list"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in NotificationPolicyTimeRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        NotificationPolicyTimeRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        NotificationPolicyTimeRestriction.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  type: str,
                  restriction: Optional[Sequence['outputs.NotificationPolicyTimeRestrictionRestriction']] = None,
-                 restrictions: Optional[Sequence['outputs.NotificationPolicyTimeRestrictionRestriction']] = None):
+                 restriction_list: Optional[Sequence['outputs.NotificationPolicyTimeRestrictionRestrictionList']] = None):
         """
         :param str type: Defines if restriction should apply daily on given hours or on certain days and hours. Possible values are: `time-of-day`, `weekday-and-time-of-day`
         :param Sequence['NotificationPolicyTimeRestrictionRestrictionArgs'] restriction: A definition of hourly definition applied daily, this has to be used with combination: type = `time-of-day`. This is a block, structure is documented below.
-        :param Sequence['NotificationPolicyTimeRestrictionRestrictionArgs'] restrictions: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
+        :param Sequence['NotificationPolicyTimeRestrictionRestrictionListArgs'] restriction_list: List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -2511,16 +2635,90 @@ class NotificationPolicyTimeRestriction(dict):
         return pulumi.get(self, "restriction")
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[Sequence['outputs.NotificationPolicyTimeRestrictionRestriction']]:
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[Sequence['outputs.NotificationPolicyTimeRestrictionRestrictionList']]:
         """
         List of days and hours definitions for field type = `weekday-and-time-of-day`. This is a block, structure is documented below.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
 
 @pulumi.output_type
 class NotificationPolicyTimeRestrictionRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "endHour":
+            suggest = "end_hour"
+        elif key == "endMin":
+            suggest = "end_min"
+        elif key == "startHour":
+            suggest = "start_hour"
+        elif key == "startMin":
+            suggest = "start_min"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in NotificationPolicyTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        NotificationPolicyTimeRestrictionRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        NotificationPolicyTimeRestrictionRestriction.__key_warning(key)
+        return super().get(key, default)
+
+    def __init__(__self__, *,
+                 end_hour: int,
+                 end_min: int,
+                 start_hour: int,
+                 start_min: int):
+        """
+        :param int end_hour: Ending hour of restriction.
+        :param int end_min: Ending minute of restriction on defined `end_hour`
+        :param int start_hour: Starting hour of restriction.
+        :param int start_min: Staring minute of restriction on defined `start_hour`
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> int:
+        """
+        Ending hour of restriction.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> int:
+        """
+        Ending minute of restriction on defined `end_hour`
+        """
+        return pulumi.get(self, "end_min")
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> int:
+        """
+        Starting hour of restriction.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> int:
+        """
+        Staring minute of restriction on defined `start_hour`
+        """
+        return pulumi.get(self, "start_min")
+
+
+@pulumi.output_type
+class NotificationPolicyTimeRestrictionRestrictionList(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
@@ -2538,14 +2736,14 @@ class NotificationPolicyTimeRestrictionRestriction(dict):
             suggest = "start_min"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in NotificationPolicyTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in NotificationPolicyTimeRestrictionRestrictionList. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        NotificationPolicyTimeRestrictionRestriction.__key_warning(key)
+        NotificationPolicyTimeRestrictionRestrictionList.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        NotificationPolicyTimeRestrictionRestriction.__key_warning(key)
+        NotificationPolicyTimeRestrictionRestrictionList.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,
@@ -3037,20 +3235,37 @@ class ScheduleRotationParticipant(dict):
 
 @pulumi.output_type
 class ScheduleRotationTimeRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "restrictionList":
+            suggest = "restriction_list"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in ScheduleRotationTimeRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        ScheduleRotationTimeRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        ScheduleRotationTimeRestriction.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  type: str,
                  restriction: Optional[Sequence['outputs.ScheduleRotationTimeRestrictionRestriction']] = None,
-                 restrictions: Optional[Sequence['outputs.ScheduleRotationTimeRestrictionRestriction']] = None):
+                 restriction_list: Optional[Sequence['outputs.ScheduleRotationTimeRestrictionRestrictionList']] = None):
         """
         :param str type: This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
         :param Sequence['ScheduleRotationTimeRestrictionRestrictionArgs'] restriction: It is a restriction object which is described below. In this case startDay/endDay fields are not supported. This can be used only if time restriction type is `time-of-day`.
-        :param Sequence['ScheduleRotationTimeRestrictionRestrictionArgs'] restrictions: It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
+        :param Sequence['ScheduleRotationTimeRestrictionRestrictionListArgs'] restriction_list: It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         """
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -3069,16 +3284,90 @@ class ScheduleRotationTimeRestriction(dict):
         return pulumi.get(self, "restriction")
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[Sequence['outputs.ScheduleRotationTimeRestrictionRestriction']]:
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[Sequence['outputs.ScheduleRotationTimeRestrictionRestrictionList']]:
         """
         It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
         """
-        return pulumi.get(self, "restrictions")
+        return pulumi.get(self, "restriction_list")
 
 
 @pulumi.output_type
 class ScheduleRotationTimeRestrictionRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "endHour":
+            suggest = "end_hour"
+        elif key == "endMin":
+            suggest = "end_min"
+        elif key == "startHour":
+            suggest = "start_hour"
+        elif key == "startMin":
+            suggest = "start_min"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in ScheduleRotationTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        ScheduleRotationTimeRestrictionRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        ScheduleRotationTimeRestrictionRestriction.__key_warning(key)
+        return super().get(key, default)
+
+    def __init__(__self__, *,
+                 end_hour: int,
+                 end_min: int,
+                 start_hour: int,
+                 start_min: int):
+        """
+        :param int end_hour: Value of the hour that frame will end.
+        :param int end_min: Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        :param int start_hour: Value of the hour that frame will start.
+        :param int start_min: Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> int:
+        """
+        Value of the hour that frame will end.
+        """
+        return pulumi.get(self, "end_hour")
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> int:
+        """
+        Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        return pulumi.get(self, "end_min")
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> int:
+        """
+        Value of the hour that frame will start.
+        """
+        return pulumi.get(self, "start_hour")
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> int:
+        """
+        Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+        """
+        return pulumi.get(self, "start_min")
+
+
+@pulumi.output_type
+class ScheduleRotationTimeRestrictionRestrictionList(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
@@ -3096,14 +3385,14 @@ class ScheduleRotationTimeRestrictionRestriction(dict):
             suggest = "start_min"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in ScheduleRotationTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in ScheduleRotationTimeRestrictionRestrictionList. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        ScheduleRotationTimeRestrictionRestriction.__key_warning(key)
+        ScheduleRotationTimeRestrictionRestrictionList.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        ScheduleRotationTimeRestrictionRestriction.__key_warning(key)
+        ScheduleRotationTimeRestrictionRestrictionList.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,
@@ -3645,15 +3934,32 @@ class TeamRoutingRuleNotify(dict):
 
 @pulumi.output_type
 class TeamRoutingRuleTimeRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "restrictionList":
+            suggest = "restriction_list"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in TeamRoutingRuleTimeRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        TeamRoutingRuleTimeRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        TeamRoutingRuleTimeRestriction.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  type: str,
                  restriction: Optional[Sequence['outputs.TeamRoutingRuleTimeRestrictionRestriction']] = None,
-                 restrictions: Optional[Sequence['outputs.TeamRoutingRuleTimeRestrictionRestriction']] = None):
+                 restriction_list: Optional[Sequence['outputs.TeamRoutingRuleTimeRestrictionRestrictionList']] = None):
         pulumi.set(__self__, "type", type)
         if restriction is not None:
             pulumi.set(__self__, "restriction", restriction)
-        if restrictions is not None:
-            pulumi.set(__self__, "restrictions", restrictions)
+        if restriction_list is not None:
+            pulumi.set(__self__, "restriction_list", restriction_list)
 
     @property
     @pulumi.getter
@@ -3666,13 +3972,69 @@ class TeamRoutingRuleTimeRestriction(dict):
         return pulumi.get(self, "restriction")
 
     @property
-    @pulumi.getter
-    def restrictions(self) -> Optional[Sequence['outputs.TeamRoutingRuleTimeRestrictionRestriction']]:
-        return pulumi.get(self, "restrictions")
+    @pulumi.getter(name="restrictionList")
+    def restriction_list(self) -> Optional[Sequence['outputs.TeamRoutingRuleTimeRestrictionRestrictionList']]:
+        return pulumi.get(self, "restriction_list")
 
 
 @pulumi.output_type
 class TeamRoutingRuleTimeRestrictionRestriction(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "endHour":
+            suggest = "end_hour"
+        elif key == "endMin":
+            suggest = "end_min"
+        elif key == "startHour":
+            suggest = "start_hour"
+        elif key == "startMin":
+            suggest = "start_min"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in TeamRoutingRuleTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        TeamRoutingRuleTimeRestrictionRestriction.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        TeamRoutingRuleTimeRestrictionRestriction.__key_warning(key)
+        return super().get(key, default)
+
+    def __init__(__self__, *,
+                 end_hour: int,
+                 end_min: int,
+                 start_hour: int,
+                 start_min: int):
+        pulumi.set(__self__, "end_hour", end_hour)
+        pulumi.set(__self__, "end_min", end_min)
+        pulumi.set(__self__, "start_hour", start_hour)
+        pulumi.set(__self__, "start_min", start_min)
+
+    @property
+    @pulumi.getter(name="endHour")
+    def end_hour(self) -> int:
+        return pulumi.get(self, "end_hour")
+
+    @property
+    @pulumi.getter(name="endMin")
+    def end_min(self) -> int:
+        return pulumi.get(self, "end_min")
+
+    @property
+    @pulumi.getter(name="startHour")
+    def start_hour(self) -> int:
+        return pulumi.get(self, "start_hour")
+
+    @property
+    @pulumi.getter(name="startMin")
+    def start_min(self) -> int:
+        return pulumi.get(self, "start_min")
+
+
+@pulumi.output_type
+class TeamRoutingRuleTimeRestrictionRestrictionList(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
@@ -3690,14 +4052,14 @@ class TeamRoutingRuleTimeRestrictionRestriction(dict):
             suggest = "start_min"
 
         if suggest:
-            pulumi.log.warn(f"Key '{key}' not found in TeamRoutingRuleTimeRestrictionRestriction. Access the value via the '{suggest}' property getter instead.")
+            pulumi.log.warn(f"Key '{key}' not found in TeamRoutingRuleTimeRestrictionRestrictionList. Access the value via the '{suggest}' property getter instead.")
 
     def __getitem__(self, key: str) -> Any:
-        TeamRoutingRuleTimeRestrictionRestriction.__key_warning(key)
+        TeamRoutingRuleTimeRestrictionRestrictionList.__key_warning(key)
         return super().__getitem__(key)
 
     def get(self, key: str, default = None) -> Any:
-        TeamRoutingRuleTimeRestrictionRestriction.__key_warning(key)
+        TeamRoutingRuleTimeRestrictionRestrictionList.__key_warning(key)
         return super().get(key, default)
 
     def __init__(__self__, *,

--- a/sdk/python/pulumi_opsgenie/team_routing_rule.py
+++ b/sdk/python/pulumi_opsgenie/team_routing_rule.py
@@ -319,7 +319,7 @@ class TeamRoutingRule(pulumi.CustomResource):
             order=0,
             team_id=test_team.id,
             time_restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionArgs(
-                restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionArgs(
+                restriction_list=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionListArgs(
                     end_day="tuesday",
                     end_hour=18,
                     end_min=30,
@@ -387,7 +387,7 @@ class TeamRoutingRule(pulumi.CustomResource):
             order=0,
             team_id=test_team.id,
             time_restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionArgs(
-                restrictions=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionArgs(
+                restriction_list=[opsgenie.TeamRoutingRuleTimeRestrictionRestrictionListArgs(
                     end_day="tuesday",
                     end_hour=18,
                     end_min=30,


### PR DESCRIPTION
Resolves #57

This pull request adds explicit support for the two different types of `TimeRestriction` nested resource, specifically for these four top-level resources:

- TeamRoutingRule
- NotificationPolicy
- ScheduleRotation
- AlertPolicy

This is a BREAKING CHANGE in the schema:

- All time restrictions of type `weekday-and-time-of-day` should use `NotificationPolicyTimeRestrictionRestrictionList` going forward.
- All time restrictions of type `time-of-day` should use `NotificationPolicyTimeRestrictionRestriction`

As this behavior was implemented incorrectly before, breaking the schema is the path forward here.
